### PR TITLE
Derive a registry-served agent's address from its name and version

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -229,6 +229,20 @@ version. `serves` is what makes a worker fleet-manageable: which process can run
 which agent is declarative, so you can shard agents across workers, or run a
 canary worker holding only `v2` while the fleet stays on `v1`.
 
+An agent served from a registry adds `repository`, and each version is pulled from
+`<repository>/<agent>:v<N>` — the address `charter push` writes to, derived rather
+than typed:
+
+```yaml
+serves:
+  - agent: refund-triage
+    versions: [1, 2]
+    repository: ghcr.io/acme/agents
+```
+
+`ref` names one artifact instead, and takes no `versions`: serving two versions
+that way is two entries, and nothing checks the second was written.
+
 `versions` is a list rather than a single number for the rollback reason above —
 dropping a version from a worker that a lifecycle rule might roll back to leaves
 the control plane dispatching operations nobody can handle.
@@ -689,7 +703,7 @@ Not versioned. Every secret is an `${ENV_VAR}` reference, never a literal.
 | `control_plane` | yes | `endpoint`, `api_key`, `tenant_id` |
 | `llm` | yes | `provider` (`anthropic` \| `langchain`), `api_key` |
 | `agents_dir` | no | default `./agents`, relative to this file |
-| `serves[]` | yes | `{agent, versions: [int]}` — every version any rollback might target |
+| `serves[]` | yes | `{agent, versions: [int], repository?}` or `{ref}` — every version any rollback might target |
 | `notifications.channels[]` | no | `{name, kind: webhook, url, secret?, timeout_seconds=5, max_attempts=3}` |
 | `notifications.routes[]` | no | `{agent?, events?, channel}`, first match wins; omit `agent` for a catch-all |
 | `trace_sink` | no | `{kind: none\|logging\|jsonl\|otel, path?, endpoint?}` |

--- a/charter/artifact.py
+++ b/charter/artifact.py
@@ -50,7 +50,13 @@ class Packed:
 
     def reference(self, repository: str) -> str:
         """`registry/repo/agent:v1` — the ref a worker is pointed at."""
-        return f"{repository.rstrip('/')}/{self.agent}:{self.tag}"
+        return ref_for(repository, self.agent, self.version)
+
+
+def ref_for(repository: str, agent: str, version: int) -> str:
+    """The address of one version: `registry/repo/agent:v<N>`. The same address
+    `charter push` writes, so publishing and pulling agree by construction."""
+    return f"{repository.rstrip('/')}/{agent}:v{version}"
 
 
 def pack(bundle, version: int) -> Packed:
@@ -164,12 +170,15 @@ def pull(ref: str, into: Path, *, insecure: bool = False) -> Path:
 
     import oras.client
 
-    agent = ref.rsplit("/", 1)[-1].split(":")[0]
+    last = ref.rsplit("/", 1)[-1]
+    agent, _, tag = last.partition(":")
     directory = into / agent
     directory.mkdir(parents=True, exist_ok=True)
 
     client = oras.client.OrasClient(insecure=insecure)
-    got = client.pull(target=ref, outdir=str(into / f".{agent}-blob"))
+    # A blob directory per ref: several versions unpack into one tree, and a
+    # shared one could hand back an earlier pull's layer.
+    got = client.pull(target=ref, outdir=str(into / f".{agent}-{tag or 'latest'}-blob"))
     blobs = [Path(p) for p in got if Path(p).is_file()]
     if not blobs:
         raise ValueError(f"{ref} held nothing — is it a Charter agent artifact?")

--- a/charter/config/worker.py
+++ b/charter/config/worker.py
@@ -75,13 +75,20 @@ class Served(Base):
         serves:
           - agent: leads-finder          # from ./leads-finder
             versions: [1]
+          - agent: leads-finder          # from ghcr.io/acme/agents/leads-finder
+            versions: [1, 2]
+            repository: ghcr.io/acme/agents
           - ref: ghcr.io/acme/agents/leads-finder:v1
 
     `versions` is a list, not a single number, because a `set_version` rollback
     dispatches operations at the old version and this process must still be able to
     build that agent. Dropping a version a lifecycle rule can target strands the
-    control plane. A ref names one version — its own — so serving two means two
-    entries, which is honest: they are two artifacts.
+    control plane.
+
+    `repository` derives one address per version, so a registry-served agent takes
+    the same `versions` list a directory does. `ref` names one artifact and cannot:
+    serving two versions that way means two entries, and nothing checks you wrote
+    the second.
     """
 
     agent: str | None = Field(default=None, pattern=AGENT_NAME)
@@ -91,10 +98,14 @@ class Served(Base):
     ref: str | None = Field(default=None, description=(
         "An OCI reference like ghcr.io/acme/agents/leads-finder:v1. The artifact "
         "names its own agent and version, so neither is repeated here."))
+    repository: str | None = Field(default=None, description=(
+        "Where this agent's artifacts live, like ghcr.io/acme/agents. Each served "
+        "version is pulled from `<repository>/<agent>:v<N>` — the same address "
+        "`charter push` writes to."))
 
     @property
     def from_registry(self) -> bool:
-        return self.ref is not None
+        return self.ref is not None or self.repository is not None
 
     @model_validator(mode="after")
     def _check(self) -> Served:
@@ -102,6 +113,17 @@ class Served(Base):
             raise ValueError(
                 "give either `agent` (a directory) or `ref` (a registry artifact), "
                 "not both — an artifact names the agent it holds")
+        if self.ref and self.repository:
+            raise ValueError(
+                "`ref` and `repository` both address the artifact: `ref` names one "
+                "version, `repository` derives every version from the agent name")
+        if self.repository:
+            # Only the last segment is checked: a registry may carry a port,
+            # localhost:5000/acme.
+            if ":" in self.repository.rsplit("/", 1)[-1]:
+                raise ValueError(
+                    f"{self.repository!r} carries a tag — `repository` is the path "
+                    f"agents live under, and the version is appended per entry")
         if self.ref:
             if self.versions:
                 raise ValueError(

--- a/charter/worker.py
+++ b/charter/worker.py
@@ -204,9 +204,28 @@ class CharterWorker:
         from . import artifact, policy as charter_policy
         from .config.loader import load_agent
 
-        directory = artifact.pull(spec.ref, self._pulled, insecure=spec.insecure)
-        bundle = load_agent(directory)
-        version = max(bundle.versions)
+        if spec.repository:
+            # Every version lands in one tree, which is the layout `load_agent`
+            # already reads: v1.yaml beside v2.yaml, each with its own skills.
+            for version in sorted(spec.versions):
+                ref = artifact.ref_for(spec.repository, spec.agent, version)
+                directory = artifact.pull(ref, self._pulled, insecure=spec.insecure)
+                log.info("pulled %s v%d from %s", spec.agent, version, ref)
+            bundle = load_agent(directory)
+            versions = sorted(spec.versions)
+            absent = [v for v in versions if v not in bundle.versions]
+            if absent:
+                # The tag promised a version the artifact doesn't hold. Fatal like
+                # a failed pull, not a quarantine: nothing was served to isolate.
+                raise ValueError(
+                    f"{spec.repository}/{spec.agent} has no "
+                    f"{', '.join(f'v{v}' for v in absent)} — the artifact holds "
+                    f"{', '.join(f'v{v}' for v in sorted(bundle.versions))}")
+        else:
+            directory = artifact.pull(spec.ref, self._pulled, insecure=spec.insecure)
+            bundle = load_agent(directory)
+            versions = [max(bundle.versions)]
+            log.info("pulled %s v%d from %s", bundle.name, versions[0], spec.ref)
 
         wf = await self._workflow_for(cp, bundle.name)
         if wf is not None:
@@ -218,8 +237,7 @@ class CharterWorker:
             # them on the next boot.
             log.warning("%s: no instance on the control plane yet — running on "
                         "default limits until one is applied", bundle.name)
-        log.info("pulled %s v%d from %s", bundle.name, version, spec.ref)
-        return bundle, [version]
+        return bundle, versions
 
     async def _workflow_for(self, cp: ControlPlaneClient, agent: str):
         for w in await cp.list_workflows():

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,8 +3,11 @@ from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
+from charter import artifact
 from charter.config.loader import ConfigError, load_agent, load_project
+from charter.config.worker import Served
 
 EXAMPLES = Path(__file__).parent.parent / "examples"
 
@@ -309,3 +312,45 @@ class TestChannelKinds:
                           {"event": "approval_requested", "agent": "leads-finder",
                            "approval_id": "apr_1", "justification": "x"})
             assert "charter approve apr_1 --agent leads-finder" in body["text"]
+
+
+class TestRepositoryServing:
+    """`repository` derives one artifact address per version, so a registry-served
+    agent can hold every version a lifecycle rule might roll back to."""
+
+    def test_versions_are_allowed_with_a_repository(self):
+        served = Served(agent="leads-finder", versions=[1, 2],
+                        repository="ghcr.io/acme/agents")
+        assert served.from_registry
+        assert served.versions == [1, 2]
+
+    def test_a_ref_still_refuses_versions(self):
+        with pytest.raises(ValidationError, match="doesn't apply to a `ref`"):
+            Served(ref="ghcr.io/acme/agents/leads-finder:v1", versions=[1])
+
+    def test_ref_and_repository_are_two_answers_to_one_question(self):
+        with pytest.raises(ValidationError, match="both address the artifact"):
+            Served(ref="ghcr.io/acme/agents/leads-finder:v1",
+                   repository="ghcr.io/acme/agents")
+
+    def test_a_tagged_repository_is_rejected(self):
+        """The version is appended, so a tag here would produce `...:v1:v2`."""
+        with pytest.raises(ValidationError, match="carries a tag"):
+            Served(agent="leads-finder", versions=[1],
+                   repository="ghcr.io/acme/agents:v1")
+
+    def test_a_registry_port_is_not_a_tag(self):
+        served = Served(agent="leads-finder", versions=[1],
+                        repository="localhost:5000/acme")
+        assert served.repository == "localhost:5000/acme"
+
+    def test_derived_ref_matches_what_push_writes(self):
+        """`charter push` and a worker pulling must name the same artifact."""
+        packed = artifact.Packed(agent="leads-finder", version=2, tar=b"",
+                                 digest="sha256:x", files=[])
+        assert (artifact.ref_for("ghcr.io/acme/agents", "leads-finder", 2)
+                == packed.reference("ghcr.io/acme/agents"))
+
+    def test_a_trailing_slash_does_not_double(self):
+        assert (artifact.ref_for("ghcr.io/acme/agents/", "leads-finder", 1)
+                == "ghcr.io/acme/agents/leads-finder:v1")


### PR DESCRIPTION
## The problem

A worker serving from a registry takes one `ref` and can hold exactly one version — `versions` is rejected, on the grounds that "an artifact is one version."

But a `set_version` rollback dispatches operations at the *old* version. If the worker doesn't hold it, the control plane dispatches work nobody can handle. `load_project` has a cross-check for exactly this ("a rollback would strand the agent") — and it `continue`s past every registry-served entry. So the mode used in production is the one without the guard, and the fix is "remember to add a second `serves` entry", which nothing verifies.

## The change

`repository` derives one address per version:

```yaml
serves:
  - agent: refund-triage
    versions: [1, 2]
    repository: ghcr.io/acme/agents
    #  →  ghcr.io/acme/agents/refund-triage:v1
    #  →  ghcr.io/acme/agents/refund-triage:v2
```

That is the same address `charter push -r` writes, via a shared `artifact.ref_for` — so publishing and pulling name the artifact by construction rather than by the operator retyping it. `Packed.reference` now delegates to it, and a test pins the two together.

Each version is pulled into one tree, which is the layout `load_agent` already reads (`v1.yaml` beside `v2.yaml`, each with its own skills), so registry serving takes the same `versions` list a directory does.

`ref` is unchanged and still means one artifact, for digest pinning, mirrors, and registries that cannot do a repository per agent.

## Also

- A `repository` carrying a tag is rejected — the version is appended, so it would produce `...:v1:v2`. Only the last segment is checked, so `localhost:5000/acme` still parses as a port.
- An artifact whose contents do not hold the version its tag promised fails boot with what it does hold, rather than silently serving fewer versions — which would be the stranding bug again.
- `artifact.pull` now uses a blob directory per ref rather than per agent. Several versions unpack into one tree, and a shared blob directory could hand back an earlier pull's layer.

## Notes

Charter-side only; no control-plane changes. The loader's rollback cross-check still cannot run for registry-served agents, since it needs the files locally — this removes the hazard it was guarding against rather than extending the check.

Tests fail without the change: `Base` sets `extra="forbid"`, so every `repository=` case raised `ValidationError` before, and `ref_for` did not exist.
