### PR TITLE
Document the six steps, skills, and the serves format that survives a rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ $ charter audit refund-triage
    versions this process serves.
 5. **Apply it** — `charter apply` arms config and policy on the control plane;
    `charter agent create` brings an instance into existence.
-6. **Run it** — `charter run`, then `charter agents` and `charter pending` to
-   operate it.
+6. **Run it** — `charter run` starts a task; `charter status` says how it went.
+7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
+   it spends, ship a `v2.yaml` when it should change, roll it back when it
+   shouldn't have.
 
 You'll need a BoundFlow control plane you can reach, and an API key for it.
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ $ charter audit refund-triage
 4. **Configure a worker** — `worker.yaml`: credentials, and which agents and
    versions this process serves.
 5. **Apply it** — `charter apply` arms config and policy on the control plane;
-   `charter agent create` makes the instance that holds the agent's state.
+   `charter agent create` instantiates the agent.
 6. **Run it** — `charter run` starts a task; `charter status` says how it went.
 7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
    it spends, add a `v2.yaml` when it should behave differently.

--- a/README.md
+++ b/README.md
@@ -211,8 +211,7 @@ $ charter audit refund-triage
    `charter agent create` makes the instance that holds the agent's state.
 6. **Run it** — `charter run` starts a task; `charter status` says how it went.
 7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
-   it spends, add a `v2.yaml` when you want it to behave differently, and roll
-   back to v1 if v2 turns out worse.
+   it spends, add a `v2.yaml` when it should behave differently.
 
 You'll need a BoundFlow control plane you can reach, and an API key for it.
 

--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ $ charter audit refund-triage
 
 ## Getting started
 
-The whole shape of the work, in order:
-
 1. **Define the agent** — `v1.yaml`: its objective, the tools it may call, which of
    them need a human.
 2. **Set its policy** — `runtime.yaml` for budgets and authority, `lifecycle.yaml`

--- a/README.md
+++ b/README.md
@@ -208,11 +208,11 @@ $ charter audit refund-triage
 4. **Configure a worker** — `worker.yaml`: credentials, and which agents and
    versions this process serves.
 5. **Apply it** — `charter apply` arms config and policy on the control plane;
-   `charter agent create` brings an instance into existence.
+   `charter agent create` makes the instance that holds the agent's state.
 6. **Run it** — `charter run` starts a task; `charter status` says how it went.
 7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
-   it spends, ship a `v2.yaml` when it should change, roll it back when it
-   shouldn't have.
+   it spends, add a `v2.yaml` when you want it to behave differently, and roll
+   back to v1 if v2 turns out worse.
 
 You'll need a BoundFlow control plane you can reach, and an API key for it.
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,21 @@ $ charter audit refund-triage
 
 ## Getting started
 
+The whole shape of the work, in order:
+
+1. **Define the agent** — `v1.yaml`: its objective, the tools it may call, which of
+   them need a human.
+2. **Set its policy** — `runtime.yaml` for budgets and authority, `lifecycle.yaml`
+   for pause, cooldown and rollback rules.
+3. **Package it** — `charter push` seals the version into your registry. Skip it
+   while developing: a worker reads a directory just as well.
+4. **Configure a worker** — `worker.yaml`: credentials, and which agents and
+   versions this process serves.
+5. **Apply it** — `charter apply` arms config and policy on the control plane;
+   `charter agent create` brings an instance into existence.
+6. **Run it** — `charter run`, then `charter agents` and `charter pending` to
+   operate it.
+
 You'll need a BoundFlow control plane you can reach, and an API key for it.
 
 Charter is not on PyPI yet, and it needs BoundFlow's `exp/deepagents-harness`
@@ -229,6 +244,7 @@ points at your checkout.
 ├── worker.yaml               # which agents this worker serves, pricing, channels
 └── leads-finder/
     ├── v1.yaml               # objective, tools, gates — versioned, immutable
+    ├── v1/skills/            # procedures for that version, shipped with it
     ├── runtime.yaml          # budgets, limits, authority — policy, not versioned
     └── lifecycle.yaml        # pause, cooldown and rollback rules
 ```
@@ -237,6 +253,28 @@ Only `v1.yaml` is required; a version file plus credentials is enough to run an
 agent. The split matters: `v1.yaml` is what the agent *does* and is versioned, so
 a rollback restores behavior. Budgets and lifecycle rules are today's guardrails
 and stay in force across one.
+
+Skills are the procedures the agent should follow once it gets there — how your
+refunds policy works, the runbook a new hire would be handed. Drop them in
+`v1/skills/<name>/SKILL.md` and they ship with that version; the layout is
+deepagents' own, so skills you already have work unchanged. They live inside `v1/`
+because rolling back to v1 should restore the instructions v1 was running with.
+
+### Which agents a worker serves
+
+```yaml
+serves:
+  - agent: leads-finder       # from ./leads-finder, while you develop
+    versions: [1]
+  - agent: refund-triage      # from the registry, once it is real
+    versions: [1, 2]
+    repository: ghcr.io/acme/agents
+```
+
+A repository derives one address per version — `<repository>/<agent>:v<N>`, the
+address `charter push` writes. List every version a lifecycle rule can roll back
+to: a worker that cannot build the old version leaves the control plane
+dispatching work nobody can handle.
 
 ### Credentials
 

--- a/demo/leads/worker.yaml
+++ b/demo/leads/worker.yaml
@@ -20,8 +20,7 @@ agents_dir: ./
 serves:
   - agent: leads-finder
     versions: [1]
-  # - ref: ghcr.io/acme/agents/leads-finder:v1
-  #   insecure: false
+  #   repository: ghcr.io/acme/agents   # pull v1 from the registry instead
 
 # notifications:
 #   channels:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,10 +44,14 @@ serve the same agents are a pool; `--scale` is the whole mechanism.
     serves:
       - agent: leads-finder     # from the mounted project — how you develop
         versions: [1]
-      - ref: ghcr.io/acme/agents/leads-finder:v1   # how you deploy
+      - agent: leads-finder     # from the registry — how you deploy
+        versions: [1, 2]
+        repository: ghcr.io/acme/agents
 
-A reference is pulled at boot. The artifact names its own agent and version, so
-neither is repeated here, and the worker needs no checkout at all.
+Each version is pulled at boot from `<repository>/<agent>:v<N>`, the address
+`charter push` writes, and the worker needs no checkout at all. Serve every
+version a lifecycle rule can roll back to — a `ref:` names one artifact instead,
+and takes no `versions`.
 
 Credentials are whatever `docker login` already wrote: the compose file mounts
 your Docker config read-only and points `DOCKER_CONFIG` at it. Nothing is

--- a/examples/worker.yaml
+++ b/examples/worker.yaml
@@ -24,6 +24,9 @@ serves:
     versions: [1]
   - agent: ticket-summarizer
     versions: [1, 2]
+    # Add a repository and the same two versions are pulled from
+    # ghcr.io/acme/agents/ticket-summarizer:v1 and :v2 instead of this checkout.
+    # repository: ghcr.io/acme/agents
 
 notifications:
   channels:


### PR DESCRIPTION
Follow-up to #9, which changed how a registry-served agent is addressed without updating what the docs tell people to write.

## The six steps

Getting started explained each file well and never said what order any of it happens in. It now opens with the sequence: define the agent, set its policy, package it, configure a worker, apply, run — with packaging marked skippable, since a worker reads a directory just as well.

## The serves format

`deploy/README.md` presented `ref: ghcr.io/.../leads-finder:v1` as "how you deploy". That is the spelling that takes no `versions`, so it cannot hold the old version a `set_version` rollback targets — the failure #9 exists to remove. Both it and the demo's commented example now show `repository`, and the README documents `serves` for the first time.

## Skills

Nothing in the docs mentioned them, though `v<N>/skills/<name>/SKILL.md` has been loaded and shipped for a while. Added to the project tree and explained in three sentences: what they are for, where they go, and why they live inside `v<N>/`.

`examples/worker.yaml` keeps directory serving as its primary form, since it is meant to run from a checkout, with the repository alternative as a comment. Both example projects still load.
