### PR TITLE
Serve BoundFlow's operator console as charter ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ $ charter audit refund-triage
    `charter agent create` instantiates the agent.
 6. **Run it** — `charter run` starts a task; `charter status` says how it went.
 7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
-   it spends, add a `v2.yaml` when it should behave differently.
+   it spends, add a `v2.yaml` when it should behave differently. `charter ui` puts
+   the same thing in a browser, for whoever decides an approval.
 
 You'll need a BoundFlow control plane you can reach, and an API key for it.
 
@@ -354,6 +355,7 @@ charter audit <agent>            # every governance decision recorded
 
 charter pending <agent>          # the open gate, if it's parked on one
 charter approve / reject / answer <id>
+charter ui                       # the same, in a browser
 
 charter pause <agent>            # stop it taking work
 charter resume <agent> --suspension <id>

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -473,6 +473,25 @@ def _manifest():
     return getattr(project, "manifest", None)
 
 
+def _console_target() -> tuple[str, str]:
+    """Endpoint and key for the console, resolved the way `_cp` resolves a client."""
+    import os
+
+    from boundflow.control_plane import DEFAULT_SERVER_ADDRESS
+
+    from .worker import resolve
+
+    manifest = _manifest()
+    if manifest is not None:
+        try:
+            return (resolve(manifest.control_plane.endpoint),
+                    resolve(manifest.control_plane.api_key))
+        except RuntimeError:
+            pass
+    return (os.environ.get("BOUNDFLOW_SERVER_ADDRESS") or DEFAULT_SERVER_ADDRESS,
+            os.environ.get("BOUNDFLOW_API_KEY", ""))
+
+
 def _cp():
     """A control-plane client, configured the same way the worker configures its own.
 
@@ -939,7 +958,10 @@ def describe(
                    # lifecycle_state is only where it happens to be right now.
                    ("status", ui.state(wf.workflow_state.value)),
                    ("activity", ui.state(ui.activity(wf.lifecycle_state.value))),
-                   ("workflow", wf.id)], indent="  ")
+                   ("workflow", wf.id)]
+                  # A cooldown ends by itself, so the question is when, not whether.
+                  + ([("cooldown until", _stamp(wf.cooldown_until))]
+                     if wf.cooldown_until else []), indent="  ")
 
             # The control plane records more about a held or dying workflow than
             # "paused" conveys, and this is the screen you run when you get paged.
@@ -1858,6 +1880,33 @@ def delete(
             ui.ok(f"{ui.ref('agent', agent)} deleted")
 
     asyncio.run(go())
+
+
+# Named for the module it isn't: `ui` at module scope is the renderer every other
+# command calls.
+@app.command("ui")
+def console_ui(
+    port: int = typer.Option(8787, "--port", help="Port to serve on (localhost only)"),
+    no_browser: bool = typer.Option(False, "--no-browser", help="Don't open a browser"),
+) -> None:
+    """Serve the operator console: every agent, its gates, and its holds.
+
+    BoundFlow's console in Charter's words, pointed at the control plane this
+    project already configures — so the person who decides an approval needs a
+    browser rather than a checkout and a CLI.
+
+    Read and act only. Authoring stays in the files, where a version is a diff
+    with an author.
+    """
+    from boundflow.ui import serve
+
+    from .console import LABELS
+
+    server, api_key = _console_target()
+    if not api_key:
+        _err("no API key — put one in worker.yaml or set BOUNDFLOW_API_KEY")
+        raise typer.Exit(1)
+    serve(server, api_key, port=port, open_browser=not no_browser, labels=LABELS)
 
 
 @app.command()

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -858,8 +858,8 @@ def agents(tenant: str = TENANT) -> None:
 
     Both states, because they answer different questions: `status` is whether a
     rule has stopped it, `activity` is whether it's waiting on you. An agent can be
-    active and blocked on a human, or paused and idle, and only one of those is
-    something you fix by approving something.
+    active and blocked on a human, or paused with nothing in flight, and only one of
+    those is something you fix by approving something.
     """
     async def go():
         from .provisioning.apply import NoSuchTenant, resolve_tenant
@@ -891,7 +891,7 @@ def agents(tenant: str = TENANT) -> None:
                 rows.append([w.workflow_type if w.workflow_type != seen else "",
                              short(w.id), f"v{w.version}",
                              ui.state(w.workflow_state.value),
-                             ui.state(ui.activity(w.lifecycle_state.value))])
+                             ui.state(w.lifecycle_state.value)])
                 seen = w.workflow_type
             # No schedule column: list_workflows returns the lighter view with
             # config unset, and a fleet view that made an extra call per agent to
@@ -957,7 +957,7 @@ def describe(
                    # workflow_state is the one that decides whether tasks start;
                    # lifecycle_state is only where it happens to be right now.
                    ("status", ui.state(wf.workflow_state.value)),
-                   ("activity", ui.state(ui.activity(wf.lifecycle_state.value))),
+                   ("activity", ui.state(wf.lifecycle_state.value)),
                    ("workflow", wf.id)]
                   # A cooldown ends by itself, so the question is when, not whether.
                   + ([("cooldown until", _stamp(wf.cooldown_until))]
@@ -1098,7 +1098,7 @@ def tasks(agent: str = typer.Argument(...),
 
             wf = await cp.get_workflow(wf.id)
             line = (f"{agent}  v{wf.version}  {ui.state(wf.workflow_state.value)}"
-                    f"  {ui.state(ui.activity(wf.lifecycle_state.value))}")
+                    f"  {ui.state(wf.lifecycle_state.value)}")
             typer.echo(line)
             if not ui.working(wf.workflow_state.value):
                 ui.warn(f"  stopped — no new tasks will start")

--- a/charter/console.py
+++ b/charter/console.py
@@ -1,0 +1,33 @@
+"""Charter's words on BoundFlow's operator console.
+
+`charter ui` serves the console from `boundflow.ui` against the control plane this
+project already points at. Only the console's own wording changes: an agent, a
+task, and the status and activity columns `charter agents` prints.
+
+What stays BoundFlow's is anything the control plane returns — `awaiting_approval`,
+`cooldown`, a workflow type. Those are what `charter describe` prints and what lands
+in the audit log, so an operator who reads one here can search for it there.
+"""
+
+from __future__ import annotations
+
+from boundflow.ui import Labels
+
+LABELS = Labels(
+    brand="Charter",
+    tagline="local agent console",
+    # A BoundFlow workflow is one Charter instance, and its type is the agent —
+    # the columns `charter agents` heads instance and agent.
+    workflow="instance",
+    workflows="instances",
+    workflow_type="agent",
+    # `charter agents` heads these columns status and activity.
+    lifecycle="activity",
+    state="status",
+    run="task",
+    runs="tasks",
+    fleet="Agents",
+    abandon="Abandon queued tasks",
+    empty_fleet="No agents yet.",
+    empty_runs="No tasks yet.",
+)

--- a/charter/ui.py
+++ b/charter/ui.py
@@ -112,13 +112,6 @@ def working(workflow_state: str) -> bool:
     return workflow_state == "active"
 
 
-def activity(lifecycle_state: str) -> str:
-    """lifecycle_state 'active' means "idle, no run in flight" — BoundFlow's own
-    docs define it that way. Printed verbatim next to a workflow_state of 'paused'
-    it reads as a contradiction, so it's shown as what it means."""
-    return "idle" if lifecycle_state == "active" else lifecycle_state
-
-
 def gate(agent: str, kind: str, gate_id: str, body: str, actions: list[str],
          timeout: str = "") -> None:
     """The one screen that should slow you down.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest", "pytest-asyncio"]
+# `charter ui` serves BoundFlow's console. The extra is theirs — starlette and
+# uvicorn arrive through it, so the two consoles can never want different ones.
+ui = ["boundflow[ui]"]
 
 [project.scripts]
 charter = "charter.cli:main"

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -34,3 +34,13 @@ def test_no_boundflow_noun_reaches_a_charter_screen():
 
 def test_the_brand_is_ours():
     assert LABELS.brand == "Charter"
+
+
+def test_charter_invents_no_word_the_control_plane_does_not_return():
+    """`idle` was printed for lifecycle_state `active`, so an operator reporting an
+    idle agent could find that word in no log, query or API response — and the
+    console, which renders stored values, disagreed with the CLI on screen."""
+    import charter.ui as ui
+
+    assert not hasattr(ui, "activity")
+    assert "idle" not in {v for v in vars(LABELS).values() if isinstance(v, str)}

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,0 +1,36 @@
+"""Charter's wording on BoundFlow's console.
+
+The console renders whatever `Labels` says, so these pin the two halves an operator
+moves between: the words match `charter agents`, and no BoundFlow noun survives
+into a Charter screen.
+"""
+import re
+from dataclasses import fields
+
+from charter.console import LABELS
+
+# BoundFlow's nouns for the things Charter renames. Substring matching would trip
+# on "runtime", so these are whole words.
+THEIRS = re.compile(r"\b(workflow|workflows|run|runs|lifecycle)\b", re.I)
+
+
+def test_the_console_says_what_charter_agents_says():
+    """`charter agents` heads its columns agent, instance, status and activity, and
+    calls one invocation a task. The agent is the workflow *type*; the workflow
+    itself is the instance — swapping those two is the mistake worth pinning."""
+    assert (LABELS.workflow, LABELS.workflow_type) == ("instance", "agent")
+    assert (LABELS.state, LABELS.lifecycle) == ("status", "activity")
+    assert (LABELS.run, LABELS.runs) == ("task", "tasks")
+
+
+def test_no_boundflow_noun_reaches_a_charter_screen():
+    """Every Labels field defaults to BoundFlow's own wording, so one added upstream
+    arrives untranslated. This fails then, rather than shipping a console that says
+    workflow on one page and agent on the next."""
+    leaked = {f.name: getattr(LABELS, f.name) for f in fields(LABELS)
+              if THEIRS.search(str(getattr(LABELS, f.name)))}
+    assert not leaked, f"untranslated: {leaked}"
+
+
+def test_the_brand_is_ours():
+    assert LABELS.brand == "Charter"


### PR DESCRIPTION
`charter ui` serves BoundFlow's operator console against the control plane `worker.yaml` already names, so the person who decides an approval needs a browser rather than a checkout, a CLI and an API key of their own.

Charter builds no UI of its own. The console is `boundflow.ui`, a client of the same control plane every read command already talks to; Charter supplies the wording and the credentials.

## The wording

`charter/console.py` holds it. A BoundFlow workflow is one Charter instance and its type is the agent, which is how `charter agents` heads those columns:

```
instance        agent           activity            status     version
wf_a3f9c012     refund-triage   awaiting_approval   active     1
wf_c8e40911     ticket-sweeper  active              active     2
```

Stored values are left alone, so `awaiting_approval` here is what `charter describe`, `--json` and the audit log return.

Two tests cover it: one pins the columns against what the CLI prints, the other fails if any `Labels` field still carries a BoundFlow noun — including one added upstream later, which would otherwise arrive untranslated.

## Depends on boundflow#96

`Labels.workflow_type` and the fleet keyboard hint are unreleased. Without them the id column is headed "agent" and the column actually holding the agent name is headed "type".

## `idle` is gone from the CLI

`charter agents` and `describe` printed `idle` where `lifecycle_state` is `active`. That word appears in no log, query or API response, so an operator reporting an idle agent had nothing to search — and the console, which renders stored values, said `active` for the same agent on the next screen.

Both say `active` now. `status` and `activity` as column headings carry what the rename was for: `active` under activity means nothing in flight, not that the agent is running.

This is a visible change to `charter agents` and `charter describe` output.

## Also

`charter describe` renders `cooldown_until`, which arrived on `WorkflowInfo` with the console. The field-coverage test caught it.

`charter[ui]` is a new extra, depending on `boundflow[ui]` so the two consoles can never want different versions of starlette and uvicorn.

290 tests pass.
