### PR TITLE
Hand the worker the trace sink its manifest declares

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,25 @@ refunds policy works, the runbook a new hire would be handed. Drop them in
 deepagents' own, so skills you already have work unchanged. They live inside `v1/`
 because rolling back to v1 should restore the instructions v1 was running with.
 
+### Traces
+
+Every model call and tool call, with its prompts, results and token counts, goes to
+a sink the worker owns:
+
+```yaml
+trace_sink:
+  kind: otel
+  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+```
+
+`otel` speaks OTLP and follows OpenTelemetry's GenAI conventions, so Jaeger, Tempo,
+Datadog and Langfuse all read it without a translation layer — `jsonl` and
+`logging` are there for when you just want to look. Traces are captured worker-side
+and carry prompts, so they go to your backend and never to the control plane.
+
+That is separate from `store.url`, which holds checkpoints and the agent's files —
+state a parked task resumes from, not telemetry.
+
 ### Which agents a worker serves
 
 ```yaml

--- a/charter/trace.py
+++ b/charter/trace.py
@@ -1,0 +1,57 @@
+"""The trace sink `worker.yaml` declares.
+
+A trace is the run tree — every model call and tool call, with prompts, results and
+token counts. It is captured in the worker and shipped to a sink you own, so it
+lands in your backend and never reaches the control plane.
+
+Separate from the store: `store.url` holds checkpoints and the agent's files, which
+is state a parked task resumes from, not telemetry.
+"""
+
+from __future__ import annotations
+
+from .config.worker import TraceSink
+
+
+def build(spec: TraceSink | None, service: str = "charter"):
+    """The sink for a manifest, or None when it declares none."""
+    if spec is None or spec.kind == "none":
+        return None
+
+    from boundflow.trace import (JsonlFileTraceSink, LoggingTraceSink,
+                                 OTelTraceSink)
+
+    from .worker import resolve
+
+    if spec.kind == "logging":
+        return LoggingTraceSink()
+    if spec.kind == "jsonl":
+        return JsonlFileTraceSink(resolve(spec.path))
+    return OTelTraceSink(_otlp_tracer(resolve(spec.endpoint), service))
+
+
+def _otlp_tracer(endpoint: str, service: str):
+    """An OTLP exporter on `endpoint`, registered as the global tracer provider.
+
+    `http://` sends without TLS; anything else uses it. The provider is global
+    because a harness or library emitting its own spans should land in the same
+    trace as the run that caused them.
+    """
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter)
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as e:
+        raise ImportError(
+            "trace_sink kind `otel` needs its optional dependencies:\n"
+            "    pip install 'charter[otel]'"
+        ) from e
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service}))
+    provider.add_span_processor(BatchSpanProcessor(
+        OTLPSpanExporter(endpoint=endpoint, insecure=endpoint.startswith("http://"))))
+    trace.set_tracer_provider(provider)
+    return provider.get_tracer("charter")

--- a/charter/worker.py
+++ b/charter/worker.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from boundflow import BoundFlowWorker, ControlPlaneClient
 from boundflow.langchain_client import LangChainLlmClient
 
-from . import ui
+from . import trace as charter_trace, ui
 from .config.loader import AgentBundle, Project
 from .config.worker import Channel, WorkerManifest
 from .mcp.client import QuarantineError, ToolSet
@@ -128,6 +128,10 @@ class CharterWorker:
                 # than becoming a second place a key could come from.
                 llm=LangChainLlmClient(lambda name: self._chat_model(name)),
                 api_key=resolve(manifest.control_plane.api_key),
+                # Traces carry prompts and tool arguments, so they go where the
+                # manifest points and never to the control plane.
+                trace_sink=charter_trace.build(
+                    manifest.trace_sink, manifest.name or "charter"),
             )
             notifier = Notifier(manifest.notifications)
 

--- a/demo/leads/worker.yaml
+++ b/demo/leads/worker.yaml
@@ -39,10 +39,11 @@ serves:
 #       agent: leads-finder
 #       events: [approval_requested, input_requested]
 
+# Every model call and tool call, with prompts and results, written where this
+# says. Use kind: otel with an endpoint to send them to your own OTLP backend.
 # trace_sink:
 #   kind: jsonl
 #   path: ./traces.jsonl
-#   endpoint: http://localhost:4318
 
 model_pricing:
   claude-haiku-4-5:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = ["pytest", "pytest-asyncio"]
 # `charter ui` serves BoundFlow's console. The extra is theirs — starlette and
 # uvicorn arrive through it, so the two consoles can never want different ones.
 ui = ["boundflow[ui]"]
+# `trace_sink: {kind: otel}` builds an OTLP exporter. Theirs again, so the sink and
+# the exporter can never disagree about the OTel version.
+otel = ["boundflow[otel]"]
 
 [project.scripts]
 charter = "charter.cli:main"

--- a/tests/e2e/test_tracing.py
+++ b/tests/e2e/test_tracing.py
@@ -1,0 +1,62 @@
+"""Traces, end to end: a real control plane, a real worker, a file on disk.
+
+`trace_sink` parsed and validated for as long as it existed while `charter worker`
+never passed it to BoundFlow, so every worker ran with tracing off however the
+manifest read. Unit tests cover the wiring; this is the one that would have caught
+it, because it asserts the file the operator was promised.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+
+import pytest
+import yaml
+
+from charter.config.loader import load_project
+from charter.worker import CharterWorker
+from tests.e2e.conftest import running, wait_for_run
+from tests.e2e.harness import factory, scripted, submits
+from tests.e2e.test_lifecycle import PLAYGROUND, one_instance
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def traced_project(tmp_path, tenant, store_url):
+    """The playground, writing traces beside itself."""
+    dst = tmp_path / "playground"
+    shutil.copytree(PLAYGROUND, dst)
+    raw = yaml.safe_load((dst / "worker.yaml").read_text())
+    raw["control_plane"]["tenant"] = tenant.name
+    raw["store"] = {"url": store_url}
+    raw.pop("notifications", None)
+    raw["trace_sink"] = {"kind": "jsonl", "path": str(tmp_path / "traces.jsonl")}
+    (dst / "worker.yaml").write_text(yaml.safe_dump(raw))
+    for agent in ("refund-demo", "ticket-sweeper", "delegator"):
+        v1 = dst / agent / "v1.yaml"
+        if v1.exists():
+            v1.write_text(v1.read_text()
+                          .replace('command: python', f'command: {sys.executable}')
+                          .replace('args: ["mcp_server.py"]',
+                                   f'args: ["{PLAYGROUND / "mcp_server.py"}"]'))
+    return load_project(dst / "worker.yaml"), tmp_path / "traces.jsonl"
+
+
+async def test_a_task_writes_a_trace_where_the_manifest_says(
+        cp, traced_project, tenant):
+    """The whole chain: worker.yaml names a sink, the worker hands it to BoundFlow,
+    and a completed task leaves a trace naming the agent that ran."""
+    project, traces = traced_project
+    wf = await one_instance(cp, project, "ticket-sweeper", tenant)
+
+    worker = CharterWorker(project, chat_model=factory(scripted(submits())))
+    async with running(worker):
+        await wait_for_run(
+            cp, await cp.invoke_workflow(wf.id, context={}), timeout=90)
+    await worker.aclose()
+
+    assert traces.exists(), "the manifest asked for traces and none were written"
+    written = [json.loads(line) for line in traces.read_text().splitlines() if line]
+    assert any(t["workflow_type"] == "ticket-sweeper" for t in written), written

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,112 @@
+"""The trace sink a worker builds from its manifest.
+
+`trace_sink` validated and did nothing for as long as it existed: the manifest
+parsed it, `BoundFlowWorker` accepted one, and `charter worker` never passed it. So
+these cover the wiring as much as the sinks.
+"""
+import ast
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+from charter import trace
+from charter.config.worker import TraceSink
+
+
+def _trace(**kw):
+    from boundflow.trace import OperationTrace
+    return OperationTrace(**{
+        "trace_id": "req_1", "workflow_id": "wf_1", "workflow_type": "leads-finder",
+        "version": 1, "operation": "invoke_entry", "outcome": "completed",
+        "failed": False, "start_ms": 0, "end_ms": 10, "agent_runs": [], **kw})
+
+
+class TestBuild:
+    def test_no_sink_declared_is_no_sink(self):
+        assert trace.build(None) is None
+
+    def test_kind_none_is_no_sink(self):
+        """Declaring it off has to reach the worker as off, not as a sink that
+        drops what it is given."""
+        assert trace.build(TraceSink(kind="none")) is None
+
+    def test_logging_and_jsonl(self, tmp_path):
+        from boundflow.trace import JsonlFileTraceSink, LoggingTraceSink
+
+        assert isinstance(trace.build(TraceSink(kind="logging")), LoggingTraceSink)
+        built = trace.build(TraceSink(kind="jsonl", path=str(tmp_path / "t.jsonl")))
+        assert isinstance(built, JsonlFileTraceSink)
+
+    def test_otel_without_its_extra_says_which_one(self):
+        """The dependency is optional, so the failure has to name the install rather
+        than surface opentelemetry's own ImportError."""
+        pytest.importorskip  # noqa: B018 - documents that this asserts the absence
+        try:
+            import opentelemetry.sdk  # noqa: F401
+        except ImportError:
+            with pytest.raises(ImportError, match=r"charter\[otel\]"):
+                trace.build(TraceSink(kind="otel", endpoint="http://localhost:4317"))
+
+    def test_a_path_resolves_from_the_environment(self, tmp_path, monkeypatch):
+        """Every other credential and path in worker.yaml is a ${VAR}; a trace path
+        written to a container's read-only mount is the failure this prevents."""
+        monkeypatch.setenv("CHARTER_TRACE_PATH", str(tmp_path / "from-env.jsonl"))
+        built = trace.build(TraceSink(kind="jsonl", path="${CHARTER_TRACE_PATH}"))
+        assert str(tmp_path / "from-env.jsonl") in repr(vars(built))
+
+
+class TestTheSinkActuallyWrites:
+    @pytest.mark.asyncio
+    async def test_a_trace_lands_in_the_file(self, tmp_path):
+        """End of the line: a real OperationTrace through the sink the manifest
+        asked for, read back off disk."""
+        path = tmp_path / "traces.jsonl"
+        sink = trace.build(TraceSink(kind="jsonl", path=str(path)))
+
+        await sink.emit(_trace())
+
+        written = json.loads(path.read_text().strip())
+        assert written["trace_id"] == "req_1"
+        assert written["workflow_type"] == "leads-finder"
+
+
+def test_the_worker_hands_its_sink_to_boundflow():
+    """The bug this file exists for. `trace_sink` parsed, validated and was never
+    passed, so every worker ran with tracing off however the manifest read."""
+    import charter.worker as worker
+
+    tree = ast.parse(Path(inspect.getfile(worker)).read_text())
+    call = next(n for n in ast.walk(tree)
+                if isinstance(n, ast.Call)
+                and getattr(n.func, "id", "") == "BoundFlowWorker")
+    assert "trace_sink" in {kw.arg for kw in call.keywords}
+
+
+def test_a_manifest_on_disk_reaches_the_worker_it_configures(tmp_path):
+    """The whole chain offline: worker.yaml -> load_project -> build -> the worker
+    BoundFlow will run. Only the control plane dispatching a run is missing, and
+    that lives in tests/e2e."""
+    import shutil
+
+    import yaml
+    from boundflow import BoundFlowWorker
+    from boundflow.trace import JsonlFileTraceSink
+
+    from charter.config.loader import load_project
+
+    project = tmp_path / "project"
+    shutil.copytree(Path(__file__).parent.parent / "examples", project)
+    manifest_path = project / "worker.yaml"
+    raw = yaml.safe_load(manifest_path.read_text())
+    raw["trace_sink"] = {"kind": "jsonl", "path": str(tmp_path / "traces.jsonl")}
+    manifest_path.write_text(yaml.safe_dump(raw))
+
+    manifest = load_project(manifest_path).manifest
+    worker = BoundFlowWorker(llm=object(), api_key="k",
+                             trace_sink=trace.build(manifest.trace_sink,
+                                                    manifest.name or "charter"))
+
+    # Private, because the alternative is a control plane dispatching a real run.
+    assert isinstance(worker._trace_sink, JsonlFileTraceSink)


### PR DESCRIPTION
`trace_sink` has been a field in `worker.yaml` that nothing read.

The manifest parsed it and validated it (`kind: otel` even required an endpoint), `BoundFlowWorker` has always accepted a `trace_sink`, and `charter worker` never passed one. So every worker ran with tracing off no matter what the file said, and `examples/worker.yaml` advertised an OTLP endpoint that did nothing. No test touched it, which is why it lasted.

## The wiring

`charter/trace.py` builds the sink the manifest asks for:

- `logging` — a line per operation
- `jsonl` — the whole trace, to a file
- `otel` — an OTLP exporter registered as the global tracer provider, so a library emitting its own spans lands in the same trace as the run that caused them

Paths and endpoints go through `resolve`, like every other value in that file, so `${CHARTER_TRACE_PATH}` works. `http://` exports without TLS, anything else with it. The optional dependency arrives as `charter[otel]` → `boundflow[otel]`, so the sink and the exporter can never disagree about the OTel version, and asking for `otel` without it names the install rather than surfacing opentelemetry's own ImportError.

## Verified against a live control plane

`tests/e2e/test_tracing.py` brings up the playground with `trace_sink: {kind: jsonl}`, runs a task through a real control plane, a real worker and a real store, and reads the trace back off disk.

Removing the one `trace_sink=` argument makes it fail on the line that matters:

```
>       assert traces.exists(), "the manifest asked for traces and none were written"
E       assert False
```

BoundFlow's own `test_trace.py` also passes against the same control plane, which covers the other half — the worker calling `emit()` with LLM and tool spans.

## Tests

8 unit tests: each kind, that `none` means none rather than a sink that drops what it is given, that `${VAR}` resolves, that a real `OperationTrace` reaches the file, and an AST check that `BoundFlowWorker` is still constructed with a `trace_sink` at all — the one that would have caught this.

## Docs

The README had nothing about traces, so an evaluator would conclude there are none. It now has a short section under Getting started, including the distinction that cost people time here: traces are telemetry and go to your backend; `store.url` is state a parked task resumes from.

Also fixes the demo's commented example, which declared `kind: jsonl` alongside an `endpoint` that jsonl never reads.

298 unit tests pass; e2e passes against a local control plane.
