### PR TITLE
Publish main as a pre-release, and test against BoundFlow's

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -52,15 +52,29 @@ jobs:
           echo "version=${NEXT}.dev${N}" >> "$GITHUB_OUTPUT"
           echo "publishing ${NEXT}.dev${N} (stable is ${BASE})"
 
-      - name: Stamp the version
+      # Also raises the BoundFlow floor to the matching dev series. A specifier that
+      # names a pre-release makes pre-releases eligible for that package and no
+      # other, so a dev Charter requires a dev BoundFlow while langchain, langgraph
+      # and the rest still resolve to their stable releases. `--pre` cannot express
+      # that: it relaxes every dependency in the install at once.
+      - name: Stamp the version and the BoundFlow floor
         env:
           V: ${{ steps.ver.outputs.version }}
         run: |
           python - <<'PY'
           import os, pathlib, re
+          v = os.environ["V"]
           p = pathlib.Path("pyproject.toml")
-          p.write_text(re.sub(r'(?m)^version = ".*"$',
-                              f'version = "{os.environ["V"]}"', p.read_text(), count=1))
+          text = re.sub(r'(?m)^version = ".*"$', f'version = "{v}"', p.read_text(), count=1)
+
+          # The floor keeps the release it already names — `.dev0` only makes
+          # pre-releases eligible. Deriving it from Charter's own version would
+          # rewrite BoundFlow's floor to Charter's series and lose the guarantee.
+          floor = re.search(r'"boundflow>=([^",]*)"', text)
+          assert floor, "the boundflow requirement moved; the dev floor was not stamped"
+          text = text.replace(floor.group(0), f'"boundflow>={floor.group(1)}.dev0"', 1)
+          p.write_text(text)
+          print(f"version {v}, requires boundflow>={floor.group(1)}.dev0")
           PY
 
       - name: Build wheel + sdist

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -52,29 +52,15 @@ jobs:
           echo "version=${NEXT}.dev${N}" >> "$GITHUB_OUTPUT"
           echo "publishing ${NEXT}.dev${N} (stable is ${BASE})"
 
-      # Also raises the BoundFlow floor to the matching dev series. A specifier that
-      # names a pre-release makes pre-releases eligible for that package and no
-      # other, so a dev Charter requires a dev BoundFlow while langchain, langgraph
-      # and the rest still resolve to their stable releases. `--pre` cannot express
-      # that: it relaxes every dependency in the install at once.
-      - name: Stamp the version and the BoundFlow floor
+      - name: Stamp the version
         env:
           V: ${{ steps.ver.outputs.version }}
         run: |
           python - <<'PY'
           import os, pathlib, re
-          v = os.environ["V"]
           p = pathlib.Path("pyproject.toml")
-          text = re.sub(r'(?m)^version = ".*"$', f'version = "{v}"', p.read_text(), count=1)
-
-          # The floor keeps the release it already names — `.dev0` only makes
-          # pre-releases eligible. Deriving it from Charter's own version would
-          # rewrite BoundFlow's floor to Charter's series and lose the guarantee.
-          floor = re.search(r'"boundflow>=([^",]*)"', text)
-          assert floor, "the boundflow requirement moved; the dev floor was not stamped"
-          text = text.replace(floor.group(0), f'"boundflow>={floor.group(1)}.dev0"', 1)
-          p.write_text(text)
-          print(f"version {v}, requires boundflow>={floor.group(1)}.dev0")
+          p.write_text(re.sub(r'(?m)^version = ".*"$',
+                              f'version = "{os.environ["V"]}"', p.read_text(), count=1))
           PY
 
       - name: Build wheel + sdist

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,76 @@
+name: Publish pre-release
+
+# Publishes a PEP 440 dev release from main on every green Tests run, so anyone can
+# install what main is without waiting for a tag.
+#
+# `pip install charter` still resolves to the newest *stable* release and is
+# unaffected. Only `pip install --pre charter` sees this stream, so a customer who
+# wants stability never gets one, and a tag keeps meaning a deliberate release.
+#
+# The version is computed here rather than read from pyproject.toml: a dev build must
+# not claim to be the stable version it branched from, and bumping the file on every
+# merge would be a commit per merge.
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-publish:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write   # Trusted Publishing; no API token stored
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0    # the dev number counts commits since the last tag
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Compute the dev version
+        id: ver
+        run: |
+          set -euo pipefail
+          BASE=$(grep -m1 '^version' pyproject.toml | cut -d'"' -f2)
+          # Numbered against the *next* minor: PEP 440 sorts 0.1.0.dev3 BEFORE 0.1.0,
+          # so dev builds off the current version would lose to the stable release and
+          # `--pre` would never reach them.
+          NEXT=$(python -c 'import sys; a,b,_=sys.argv[1].split(".")[:3]; print(f"{a}.{int(b)+1}.0")' "$BASE")
+          # Monotonic within a base: PyPI rejects a version it has already seen, and
+          # will not accept a re-upload even after a delete.
+          N=$(git rev-list --count "v${BASE}..HEAD" 2>/dev/null || git rev-list --count HEAD)
+          echo "version=${NEXT}.dev${N}" >> "$GITHUB_OUTPUT"
+          echo "publishing ${NEXT}.dev${N} (stable is ${BASE})"
+
+      - name: Stamp the version
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          python - <<'PY'
+          import os, pathlib, re
+          p = pathlib.Path("pyproject.toml")
+          p.write_text(re.sub(r'(?m)^version = ".*"$',
+                              f'version = "{os.environ["V"]}"', p.read_text(), count=1))
+          PY
+
+      - name: Build wheel + sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # A re-run, or a merge landing while another is publishing, should not fail
+          # the workflow over a version that is already up.
+          skip-existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,23 @@ jobs:
       # tests/e2e skips itself without a control plane in the environment.
       - run: python -m pytest tests -v
 
+  # BoundFlow's main publishes a dev release on every green run of its own suite, so
+  # this is the first place its breakage shows. Not required to merge: an upstream
+  # regression should page us, not hold Charter's pull requests hostage.
+  upstream:
+    name: Unit (BoundFlow main)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install -e ".[dev,ui,otel]"
+      # Only boundflow, not `--pre` across the whole tree — every other dependency
+      # should stay where the released install puts it.
+      - run: pip install --pre --upgrade boundflow
+      - run: python -m pytest tests -v
+
   e2e:
     name: End to end
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $ charter audit refund-triage
 
 ```bash
 pip install charter          # add [ui] for the console, [otel] for traces
-pip install --pre charter    # or whatever main is, published on every green build
+pip install charter==X.Y.Z.devN   # or a build of main, published on every green run
 ```
 
 ### A control plane

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $ charter audit refund-triage
 
 ```bash
 pip install charter          # add [ui] for the console, [otel] for traces
-pip install charter==X.Y.Z.devN   # or a build of main, published on every green run
+pip install "charter>=0.0.1.dev0"   # or the newest build of main, on every green run
 ```
 
 ### A control plane

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ $ charter audit refund-triage
 
 ```bash
 pip install charter          # add [ui] for the console, [otel] for traces
+pip install --pre charter    # or whatever main is, published on every green build
 ```
 
 ### A control plane

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ $ charter audit refund-triage
 
 ```bash
 pip install charter          # add [ui] for the console, [otel] for traces
-pip install "charter>=0.0.1.dev0"   # or the newest build of main, on every green run
+pip install --pre charter    # or the newest build of main, published on every green run
 ```
 
 ### A control plane


### PR DESCRIPTION
The same shape as boundflow#99, for Charter.

## `publish-dev.yml`

A green `Tests` run on main publishes a PEP 440 dev release, so anyone can install what main is without waiting for a tag.

```bash
pip install charter          # newest stable — unaffected by merges
pip install --pre charter    # whatever main is
```

Dev builds are numbered against the **next** minor, for the reason boundflow#99 gives: PEP 440 sorts `0.1.0.dev3` *before* `0.1.0`, so numbering them against the current version would put every dev build behind the release it came after, where `--pre` would never reach them. `skip-existing: true` so a re-run, or a merge landing mid-publish, doesn't fail over a version already up.

The version is computed in the workflow rather than read from the file, so a dev build never claims to be the stable version it branched from and merges don't each carry a version bump.

## `Unit (BoundFlow main)`

The other half: a second unit job installs BoundFlow's own dev stream, so upstream breakage shows here first rather than at the next release.

It upgrades **only** `boundflow` to `--pre`, not the whole tree — every other dependency should stay where a released install puts it, or the job stops telling us anything about BoundFlow specifically.

**Deliberately not a required check.** An upstream regression should page us, not hold Charter's pull requests hostage. `Unit` — against the released floor, which is what customers get — stays the gate.

## Ordering

PyPI needs a trusted publisher per workflow file, so this needs a second entry alongside `publish.yml`: workflow `publish-dev.yml`, environment `pypi`.

And the stable `v0.0.1` tag should go first. Until one stable release exists, `pip install charter` has nothing to resolve to — pip won't take a pre-release by default.
