### PR TITLE
Ship the distribution as boundflow-charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,12 @@ $ charter audit refund-triage
    the same thing in a browser, for whoever decides an approval.
 
 ```bash
-pip install boundflow-charter          # add [ui] for the console, [otel] for traces
-pip install --pre boundflow-charter    # or the newest build of main, on every green run
+pip install --pre boundflow-charter    # add [ui] for the console, [otel] for traces
 ```
+
+`--pre` is required for now: every green build of main is published, and there is
+no stable release yet. Once one is tagged, `pip install boundflow-charter` gets it
+and `--pre` keeps meaning "whatever main is".
 
 ### A control plane
 

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ $ charter audit refund-triage
    the same thing in a browser, for whoever decides an approval.
 
 ```bash
-pip install charter          # add [ui] for the console, [otel] for traces
-pip install --pre charter    # or the newest build of main, published on every green run
+pip install boundflow-charter          # add [ui] for the console, [otel] for traces
+pip install --pre boundflow-charter    # or the newest build of main, on every green run
 ```
 
 ### A control plane

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "charter"
+# The distribution is `boundflow-charter`; the package, the CLI and the config's
+# apiVersion stay `charter`. PyPI refuses the bare name, and the prefix is how this
+# is branded anyway.
+name = "boundflow-charter"
 version = "0.0.1"
 description = "Declarative, governed agents on BoundFlow — objective, tools, and policy as YAML."
 readme = "README.md"


### PR DESCRIPTION
`publish-dev.yml` fired on main and failed at the last step. PyPI refuses the name:

```
invalid-publisher: valid token, but no corresponding publisher
```

and configuring the pending publisher gives *"This project name isn't allowed"*.

`pypi.org/simple/charter/` returns 404, so nobody holds it — that message is PyPI's *prohibited* name error, not its *taken* one. Most likely typosquat protection against `charset-normalizer`, one edit away and among the most-downloaded packages there is. PyPI doesn't publish the list, and the appeals path runs days to weeks.

## The change

The distribution becomes `boundflow-charter`. Nothing else moves:

```bash
pip install boundflow-charter
```
```bash
charter apply .            # unchanged
```
```python
import charter             # unchanged
apiVersion: charter/v1     # unchanged
```

The distribution name is typed once, at install. Everything a user touches afterwards is `charter` — and the prefix is how this is branded anyway, which also answers the "charter is unsearchable" problem.

Verified: builds as `boundflow_charter-0.0.1`, both artifacts pass `twine check`, and installing the wheel into an empty venv gives a working `charter --help` and `import charter`.

## Still needed before a publish succeeds

Two pending publishers on PyPI, both owner `boundflow`, repository `charter`, environment `pypi`, project name **`boundflow-charter`** — one for `publish-dev.yml`, one for `publish.yml`. Trusted publishers are per workflow file.
