### PR TITLE
Stop a stuck test from running for hours

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
   unit:
     name: Unit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -27,6 +28,7 @@ jobs:
   upstream:
     name: Unit (BoundFlow main)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,6 +43,8 @@ jobs:
   e2e:
     name: End to end
     runs-on: ubuntu-latest
+    # The default is six hours. A hung suite should cost minutes and leave a log.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio"]
+dev = ["pytest", "pytest-asyncio", "pytest-timeout"]
 # `charter ui` serves BoundFlow's console. The extra is theirs — starlette and
 # uvicorn arrive through it, so the two consoles can never want different ones.
 ui = ["boundflow[ui]"]
@@ -77,5 +77,8 @@ include = ["charter*"]
 # e2e is excluded by default: it needs a running control plane. `pytest tests/e2e`
 # opts in.
 testpaths = ["tests"]
+# No test should take minutes. A control-plane call with no deadline hangs forever
+# otherwise: one did, for 1h46m, until the CI job was cancelled by hand.
+timeout = 180
 addopts = "--ignore=tests/e2e"
 asyncio_mode = "auto"


### PR DESCRIPTION
A `Tests` run on main hung at 85% and sat there for **1h46m** until I cancelled it by hand.

It stopped in `test_pinning_a_task_id_is_what_makes_a_follow_up_continue`. Unlike its neighbours that test never calls `wait_for_run`, so it has no timeout anywhere — just `invoke_workflow` and `get_request_info` with no gRPC deadline. Nothing in the suite or the job bounded it, and a GitHub job's default limit is six hours.

## Why it mattered beyond the wasted minutes

`publish-dev.yml` triggers on `workflow_run` **completing** successfully. A hang never completes, so the pre-release publish for that commit never fired — silence rather than a red run.

## The change

- `pytest-timeout`, capping any test at 180s. A stalled call now fails with a traceback naming it instead of stalling quietly. No unit test comes close to that; the slowest e2e is well under it.
- `timeout-minutes` on all three jobs (10 / 10 / 20) as the backstop for a hang *outside* a test — a wedged compose, a pip resolve that never returns.

## What this does not do

It bounds the symptom; it doesn't explain it. Why a control-plane call stalled indefinitely is still open, and is being investigated separately — this is what makes that investigation possible, since a hung job hides its logs entirely until it is cancelled.

It's also a second failure mode, distinct from the stale-worker interference behind the other flaky e2e failures.

303 unit tests pass.
