### PR TITLE
Let the scripted model survive a replay, which the tests already provoke

### DIFF
--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -88,8 +88,14 @@ def scripted(*turns: dict) -> BaseChatModel:
                 # Subagents answer and return, so the script belongs to the parent.
                 turn = {"text": "subagent done"}
             else:
-                turn = turns[self.n] if self.n < len(turns) else {"text": "done"}
-                self.n += 1
+                # Which turn this is, read off the thread rather than counted on
+                # this object. An operation is at-least-once — `resumable=True` — so
+                # a re-dispatched round replays, and a counter would resume partway
+                # through the script and run off the end, answering "done" where the
+                # test expected a tool call.
+                i = sum(1 for m in messages if isinstance(m, AIMessage))
+                turn = turns[i] if i < len(turns) else {"text": "done"}
+                self.n = i + 1
             # Usage is not optional. BoundFlow refuses to run a model that reports
             # none — it cannot price the call, and a cost cap that silently doesn't
             # apply is worse than no cap. So the fake reports it, which is the same


### PR DESCRIPTION
## The evidence

Five runs of the e2e suite against a local control plane, before any change:

```
run1: 25 passed
run2: 25 passed
run3: FAILED test_a_task_runs_and_publishes_what_the_agent_returned
run4: FAILED test_an_approval_resumes_the_same_conversation
run5: FAILED test_an_approval_resumes_the_same_conversation
```

Three in five, always in `test_lifecycle.py`, and always with the same line:

```
task failed: agent=ticket-sweeper reason=the agent stopped without calling
submit_result … (it said: done)
```

## What "done" means

It is not another test's model, which is what I assumed for a while. `"done"` is what `scripted()` answers **once it runs out of turns** — so the model was reaching the end of a script the test had barely started.

Charter sets `resumable=True`, which makes an operation at-least-once: a re-dispatched round runs again. The model tracked its position with `self.n`, a counter on the object, so a replay kept advancing it — the replayed round resumed partway through the script and fell off the end.

The tests were assuming exactly-once model turns against a system that deliberately promises the opposite.

## The change

The turn index is read off the thread — counting the agent's own prior messages — instead of counted on the model. A replayed round sees the same history and plays the same turn.

A real model has this property for free, because it responds to the conversation. Only a scripted one holding hidden state doesn't.

## Result

Five consecutive clean runs, against three failures in five before.

```
run6:  25 passed        run9:  25 passed
run7:  25 passed        run10: 25 passed
run8:  25 passed
```

## Not fixed here

The `test_pinning_a_task_id_is_what_makes_a_follow_up_continue` **hang** is a different fault — `ControlPlaneClient` sets no gRPC deadlines, so a stalled call blocks forever. #16 bounds it; the underlying missing deadlines are upstream.
