### PR TITLE
Run any model LangChain can build, not only Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,7 @@ a remote control plane.
 install that integration (`pip install "boundflow-charter[openai]"`) and name it.
 A local runtime needs no `api_key`, and `base_url` reaches an OpenAI-compatible
 server you host. The one requirement is that the model reports token usage:
-BoundFlow refuses to run one that doesn't, because a cost cap it cannot price
-isn't a cap.
+BoundFlow refuses to run one that doesn't.
 
 Inference is bring-your-own: your model key stays in the worker environment and
 model traffic never reaches the control plane. The CLI reads this same file, so

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ control_plane:
   tenant: default
 
 llm:
-  provider: anthropic
+  provider: anthropic          # or openai, google_genai, bedrock, ollama, …
   api_key: ${ANTHROPIC_API_KEY}
 
 store:
@@ -331,6 +331,13 @@ separately — on two ports locally, and on two hosts in Cloud. Leave
 `worker_endpoint` out and workers fall back to `BOUNDFLOW_WORKER_ADDRESS`, then to
 localhost, which is what you want while developing and never what you want against
 a remote control plane.
+
+`provider` is whatever LangChain can build, so a model it supports works here —
+install that integration (`pip install "boundflow-charter[openai]"`) and name it.
+A local runtime needs no `api_key`, and `base_url` reaches an OpenAI-compatible
+server you host. The one requirement is that the model reports token usage:
+BoundFlow refuses to run one that doesn't, because a cost cap it cannot price
+isn't a cap.
 
 Inference is bring-your-own: your model key stays in the worker environment and
 model traffic never reaches the control plane. The CLI reads this same file, so

--- a/charter/config/worker.py
+++ b/charter/config/worker.py
@@ -46,8 +46,16 @@ class Llm(Base):
     comes from and which provider integration to build.
     """
 
-    provider: Literal["anthropic"] = "anthropic"
-    api_key: str = Field(min_length=1)
+    provider: str = Field(default="anthropic", min_length=1, description=(
+        "Any provider LangChain can build: anthropic, openai, google_genai, "
+        "bedrock, ollama, huggingface, groq, mistralai, xai. The list is theirs, "
+        "so it is not enumerated here — an unknown one fails at boot, naming it."))
+    # Optional: a local runtime needs no key, and some providers take credentials
+    # from the environment (bedrock from AWS's chain, vertex from ADC).
+    api_key: str = ""
+    # For an OpenAI-compatible server you host — vLLM, LM Studio, llama.cpp — or a
+    # provider on a non-default host.
+    base_url: str = ""
 
 
 class Store(Base):

--- a/charter/worker.py
+++ b/charter/worker.py
@@ -101,13 +101,26 @@ class CharterWorker:
         """
         if self.chat_model is not None:
             return self.chat_model(model)
-        from langchain_anthropic import ChatAnthropic
+        from langchain.chat_models import init_chat_model
 
-        manifest = self.project.manifest
-        if manifest.llm.provider != "anthropic":
+        llm = self.project.manifest.llm
+        # LangChain's own factory, so the providers Charter serves are the ones it
+        # serves — and a new one there needs nothing here. What it cannot supply is
+        # token usage: BoundFlow refuses a model that reports none, because a cost
+        # cap it cannot price is not a cap.
+        extra = {}
+        if llm.api_key:
+            extra["api_key"] = resolve(llm.api_key)
+        if llm.base_url:
+            extra["base_url"] = resolve(llm.base_url)
+        try:
+            return init_chat_model(model, model_provider=llm.provider, **extra)
+        except Exception as e:
             raise RuntimeError(
-                f"llm provider {manifest.llm.provider!r} is declared but not wired up")
-        return ChatAnthropic(model=model, api_key=resolve(manifest.llm.api_key))
+                f"could not build {llm.provider!r} model {model!r}: {e}. "
+                f"Its integration package may not be installed — "
+                f"langchain-{llm.provider.replace('_', '-')} or equivalent"
+            ) from e
 
     async def run(self) -> None:
         manifest = self.project.manifest

--- a/charter/worker.py
+++ b/charter/worker.py
@@ -105,9 +105,8 @@ class CharterWorker:
 
         llm = self.project.manifest.llm
         # LangChain's own factory, so the providers Charter serves are the ones it
-        # serves — and a new one there needs nothing here. What it cannot supply is
-        # token usage: BoundFlow refuses a model that reports none, because a cost
-        # cap it cannot price is not a cap.
+        # serves — and a new one there needs nothing here. BoundFlow still refuses a
+        # model that reports no token usage.
         extra = {}
         if llm.api_key:
             extra["api_key"] = resolve(llm.api_key)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dependencies = [
     # `langgraph.store.postgres`.
     "langgraph-checkpoint-postgres>=3.1",
     # The only model provider wired up today — `worker.yaml` refuses any other.
+    # `init_chat_model` lives here, and it is how a provider gets built. Declared
+    # rather than inherited from deepagents: we import it directly now.
+    "langchain>=1.0",
+    # Anthropic is the only integration installed by default, because a default has
+    # to be something. Any other provider is an extra, or install its package.
     "langchain-anthropic>=0.3",
     # OCI artifacts: `charter push` publishes an agent version to the customer's
     # own registry, and the worker pulls one. Their registry, their `docker login`,
@@ -61,6 +66,13 @@ ui = ["boundflow[ui]"]
 # `trace_sink: {kind: otel}` builds an OTLP exporter. Theirs again, so the sink and
 # the exporter can never disagree about the OTel version.
 otel = ["boundflow[otel]"]
+# Model providers. `llm.provider` takes anything LangChain can build; these are
+# just the integration packages, so you can name one instead of looking it up.
+openai = ["langchain-openai>=0.2"]
+google = ["langchain-google-genai>=2.0"]
+bedrock = ["langchain-aws>=0.2"]
+ollama = ["langchain-ollama>=0.2"]
+groq = ["langchain-groq>=0.2"]
 
 [project.urls]
 Homepage = "https://github.com/boundflow/charter"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,57 @@
+"""Any model LangChain can build, not only Anthropic."""
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from charter.config.loader import load_project
+from charter.config.worker import Llm
+from charter.worker import CharterWorker
+
+EXAMPLES = Path(__file__).parent.parent / "examples"
+
+
+@pytest.fixture
+def project(tmp_path):
+    dst = tmp_path / "project"
+    shutil.copytree(EXAMPLES, dst)
+    raw = yaml.safe_load((dst / "worker.yaml").read_text())
+    raw["store"] = {"url": "postgres://x/y"}
+    (dst / "worker.yaml").write_text(yaml.safe_dump(raw))
+    return load_project(dst / "worker.yaml")
+
+
+def _worker(project, **llm):
+    raw = dict(provider="anthropic", api_key="k")
+    raw.update(llm)
+    project.manifest.llm = Llm(**raw)
+    return CharterWorker(project)
+
+
+def test_a_provider_is_not_enumerated_by_charter():
+    """The list belongs to LangChain: a provider it gains works here untouched."""
+    assert Llm(provider="openai", api_key="k").provider == "openai"
+    assert Llm(provider="ollama").provider == "ollama"
+
+
+def test_a_local_runtime_needs_no_key():
+    """Ollama, vLLM and friends authenticate nothing; requiring a key would mean
+    inventing one."""
+    assert Llm(provider="ollama").api_key == ""
+
+
+def test_a_base_url_reaches_a_server_you_host():
+    assert Llm(provider="openai", base_url="http://localhost:8000/v1").base_url
+
+
+def test_an_unbuildable_provider_says_what_to_install(project):
+    """The failure a customer actually hits is a missing integration package."""
+    worker = _worker(project, provider="not-a-provider")
+    with pytest.raises(RuntimeError, match="could not build"):
+        worker._chat_model("some-model")
+
+
+def test_anthropic_still_builds(project):
+    worker = _worker(project, provider="anthropic", api_key="k")
+    assert type(worker._chat_model("claude-haiku-4-5")).__name__ == "ChatAnthropic"


### PR DESCRIPTION
`llm.provider` was `Literal["anthropic"]`, and the worker built `ChatAnthropic` directly — so openai, bedrock, ollama and everything else were refused at parse time.

Nothing about the design required that. deepagents runs on any LangChain chat model, and BoundFlow deliberately governs whatever client you hand it — its SDK even says so. The narrowing was Charter's alone, which is a poor look for a layer whose argument is that it governs whatever you bring.

## The change

`init_chat_model` builds the model, so the providers Charter serves are the ones LangChain serves, and one added there needs nothing here.

```yaml
llm:
  provider: openai              # or google_genai, bedrock, ollama, groq, …
  api_key: ${OPENAI_API_KEY}
  base_url: ${LOCAL_LLM_URL}    # optional: an OpenAI-compatible server you host
```

- **`api_key` is now optional.** A local runtime authenticates nothing, and bedrock and vertex read credentials from elsewhere. Requiring one meant inventing one.
- **`base_url`** reaches vLLM, LM Studio, llama.cpp, or a provider on a non-default host.
- **The provider list is not enumerated in the schema.** It is LangChain's, and a copy here would drift behind it. An unknown provider fails at boot naming the integration package to install — which is the error people actually hit.
- **Extras** for the common ones: `boundflow-charter[openai]`, `[google]`, `[bedrock]`, `[ollama]`, `[groq]`.
- **`langchain` is now a declared dependency.** This imports `langchain.chat_models` directly and was getting the package transitively through deepagents, which is the kind of thing that breaks on somebody else's resolver.

## The one constraint that survives

Token usage. BoundFlow **raises** rather than run a model reporting no `usage_metadata`, because a cost cap it cannot price is not a cap. That rules out some local setups, so it is stated in the README beside the provider list rather than left to be discovered.

## Tests

Five, covering the provider not being Charter's to enumerate, a local runtime needing no key, `base_url`, an unbuildable provider naming what to install, and Anthropic still building. Before this change `Llm(provider="openai")` failed validation outright, so they exercise the change rather than restate it.

308 pass. No version bump here — that's a release decision.
