### PR TITLE
Give the reader an agent to run, not a diagram of one

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -129,7 +129,7 @@ below.
 
 ## 3. Lifecycle policy — `agents/refund-triage/lifecycle.yaml`
 
-How the agent reacts to its own history across tasks. Not versioned; always live.
+How the agent reacts to its own history across tasks. Not versioned, and always live.
 
 Rules act on the workflow. Charter does not expose BoundFlow's *agent* lifecycle
 policy, so a rule never changes the model or the caps: those are declared in the
@@ -207,12 +207,12 @@ plane.
 `provider` is whatever LangChain can build, so a model it supports works here —
 install that integration and name it. A local runtime needs no `api_key`, and
 `base_url` reaches an OpenAI-compatible server you host. The model must report
-token usage; BoundFlow refuses to run one that doesn't.
+token usage. BoundFlow refuses to run one that doesn't.
 
 `trace_sink` takes every model call and tool call, with its prompts, results and
 token counts, to a sink the worker owns. `otel` speaks OTLP and follows
 OpenTelemetry's GenAI conventions, so Jaeger, Tempo, Datadog and Langfuse read it
-without a translation layer; `jsonl` and `logging` are there for when you just want
+without a translation layer. `jsonl` and `logging` are there for when you just want
 to look. Traces carry prompts, so they go to your backend and never to the control
 plane — which is what makes them different from `store.url`, holding the checkpoints
 and files a parked task resumes from.
@@ -271,7 +271,7 @@ has to hold. A built-in `slack:` channel is a later convenience, not a v1 need.
 
 **Notification is entirely a worker concern.** Agent configs contain no
 notification fields at all — not even a channel name. An agent with an approval
-gate *must* notify someone; that isn't an agent-author decision, and making the
+gate *must* notify someone. That isn't an agent-author decision, and making the
 config name a channel would point an immutable, committed file at something owned
 by whoever deploys the worker.
 
@@ -364,7 +364,7 @@ echo '{"ticket_id":"4821"}' | charter run refund-triage --inputs-file -
 A missing or unknown flag prints the `inputs` block — types, defaults, enums, and
 descriptions — so the config file is the only place a task's interface is written
 down. It isn't in `--help`, because Typer builds that before the agent is named. Values are validated and coerced before the request is
-created; an unknown flag or a missing required input fails locally, without
+created. An unknown flag or a missing required input fails locally, without
 burning a run.
 
 All three forms end at `invoke_workflow(context={...})`, returning the request id
@@ -378,7 +378,7 @@ bounded budget, a declared result shape, a terminal `Complete(result=...)`. So
 task = one BoundFlow request, and the budgets in `per_run` are what bound it.
 
 That naming is what makes "just trust the agent to go do stuff" coherent rather
-than alarming. Unbounded trust has no scope to be bounded by; trust *within a
+than alarming. Unbounded trust has no scope to be bounded by. Trust *within a
 task* does — the agent is free to reason, retry, and call every `read` tool it
 wants, spending up to that task's budget, and the only thing it cannot do
 unilaterally is the irreversible edge. Every guardrail in Charter is scoped to a
@@ -455,7 +455,7 @@ unnecessary question, and the failure mode where it doesn't ask lands back on th
 normal path — it calls a gated tool, stopped exactly as before.
 
 **Where do you specify the final action? You don't — that's the product.** You
-specify the menu and the objective; the agent chooses which actions to take and in
+specify the menu and the objective. The agent chooses which actions to take and in
 what order, and every irreversible one stops for you. If you had to declare the
 final action you'd be writing a workflow, and you'd want BoundFlow's SDK instead.
 
@@ -483,7 +483,7 @@ folds into history, and the loop re-enters. So one task can take several actions
 (refund, then close the ticket), each gated separately, and the agent sees what each
 call returned before it reports what it did.
 
-`entry` is the only place that stages context and calls the agent; every re-entry
+`entry` is the only place that stages context and calls the agent. Every re-entry
 is "fold in new information, run again." It also owns the `per_run` counters,
 since those are the constraint BoundFlow can't enforce for it.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,7 @@ Four files, with different lifetimes:
 | File | What it is | Versioned? | Compiles to |
 |---|---|---|---|
 | `agents/<name>/v<N>.yaml` | Configuration — objective, inputs, MCP tools | **Yes** | `WorkflowConfig(version=N)` + the agent definition the generic handler runs |
-| `agents/<name>/runtime.yaml` | Runtime policy — hard caps per iteration | No | `set_agent_runtime_policy` |
+| `agents/<name>/runtime.yaml` | Runtime policy — hard caps per run | No | `set_agent_runtime_policy` |
 | `agents/<name>/lifecycle.yaml` | Lifecycle policy — how it reacts over time | No | `set_workflow_lifecycle_policy` |
 | `worker.yaml` | Which agents + versions this worker process serves | No | `@worker.workflow(type, version=N)` registrations |
 
@@ -131,9 +131,9 @@ below.
 
 How the agent reacts to its own history across tasks. Not versioned; always live.
 
-**Workflow lifecycle only.** Charter deliberately does not expose BoundFlow's
-*agent* lifecycle policy (`SetModel`, `SetMaxLlmCalls`, `SetMaxCostUsd`,
-`SetMaxTokensPerCall`). See below for why.
+Rules act on the workflow. Charter does not expose BoundFlow's *agent* lifecycle
+policy, so a rule never changes the model or the caps: those are declared in the
+versioned config, and a `set_version` has to restore them.
 
 ```yaml
 apiVersion: charter/v1
@@ -162,36 +162,6 @@ anything expressible in the SDK's workflow policy is expressible in YAML.
 
 `charter schema -o .charter` writes these out as JSON Schema, so an editor
 offers the valid metrics rather than you looking them up here.
-
-### Why no agent lifecycle policy
-
-The three actions that adjust caps (`SetMaxLlmCalls`, `SetMaxCostUsd`,
-`SetMaxTokensPerCall`) would **break the dual enforcement above**. Charter sets
-BoundFlow's runtime cap equal to the declared per-run budget and accumulates the
-same number itself; an agent rule mutating BoundFlow's copy server-side leaves the
-two enforcers defending different numbers, with only one of them visible in YAML.
-
-`SetModel` breaks something worse: **it changes behavior without a version bump.**
-`model` is declared in the versioned config file. If a lifecycle rule can swap it
-out-of-band, the agent that's actually running is described by no version on disk,
-and `set_version` no longer restores a known state — which is the whole reason
-configuration is the versioned artifact.
-
-What's lost is automatic cost adaptation, and it comes back better through the
-primitive Charter already has: write a `v2.yaml` with the cheaper model, commit
-it, and let a rule move the fleet.
-
-```yaml
-  - when: { metric: cost, threshold: 5.00 }
-    then: { set_version: 2 }        # v2 = same agent, cheaper model
-```
-
-Same outcome as a `SetModel` downgrade, except the thing that changed is a file in
-git, the change is auditable, and it uses one mechanism instead of two. Every
-lifecycle action Charter exposes acts on the *agent as a managed unit* — hold it,
-slow it, or move it to a known version — which is the fleet-management posture the
-product is for. Tuning an individual agent's model economics is what the SDK is
-for.
 
 ## 4. Worker manifest — `worker.yaml`
 
@@ -279,7 +249,7 @@ the control plane dispatching operations nobody can handle.
 from YAML:
 
 1. find-or-create the workflow, type = `name`, `WorkflowConfig(version, invoke_mode)`
-2. `set_agent_runtime_policy` from `per_iteration`
+2. `set_agent_runtime_policy` from `per_run`
 3. `set_workflow_lifecycle_policy` from `rules`
 4. `activate_workflow`
 
@@ -354,24 +324,6 @@ task: the approval still exists and degrades to its existing timeout branch, whi
 is a state the state machine already handles. Failures are logged loudly, because
 "the gate opened and nobody was told" is exactly the condition an operator needs
 to find out about.
-
-### Lifecycle events are not notifiable yet
-
-`paused`, `cooldown`, and `set_version` fire in the scheduler, server-side. The
-worker is never told, so Charter has no push path for them — which is unfortunate,
-since "your agent just got paused" is the most operationally interesting event the
-product produces.
-
-Options, none of them free:
-
-- **Poll the audit log** from the worker or CLI. Works today, no BoundFlow change,
-  but it's polling and the latency is the poll interval.
-- **Server-side webhooks in BoundFlow** — the right answer, and useful to the SDK
-  independently of Charter. Notification becomes a control-plane feature emitting
-  on the same events it already writes to the audit log.
-
-Deferred until after the worker path works end to end; the audit log means nothing
-is lost in the meantime, only delayed.
 
 ## Tool failure
 
@@ -462,7 +414,7 @@ task/req_01J8Z... started
 A rejection is not a failure. The agent is told, and carries on without that
 action unless the tool sets `on_reject: fail`.
 
-### Not every mutation costs a human
+### Approval per tool
 
 The walkthrough above is the strictest setting. Each tool declares its own
 requirement:
@@ -488,7 +440,7 @@ governed: per-task budget, tool limits, the full audit trail, and lifecycle rule
 that pause or roll it back when it starts failing. That's the honest version of
 "trust the agent" — no human in the loop, but not unsupervised either.
 
-### Confidence is a reasoning tool, not a gate
+### Asking a human
 
 Approval is binary, and confidence appears in exactly one place:
 `ask_human.when` — `rarely`, `balanced`, or `eagerly`. It is a posture rather than
@@ -513,9 +465,10 @@ reply, write the row, page someone), that destination is just another tool, gate
 like the rest. There is deliberately no ungated final side effect, because "the
 last thing it does" is exactly the thing you'd most want to approve.
 
-## The state machine the generic handler runs
+## One operation, re-entered
 
-One operation, re-entered. Every park ends it; nothing is held open.
+The harness runs the agent loop. Charter's handler runs once per park: every park
+ends the operation, and nothing is held open.
 
 ```
 entry -> agent -> result      -> Complete
@@ -525,12 +478,10 @@ entry -> agent -> result      -> Complete
                 \-> wait       -> Next(delay)  -> entry
 ```
 
-**Only a result ends a task.** An approved call is a step, not a terminus: the
-tool is called, its result folds into history, and the loop re-enters. That buys
-three things — an agent can take several actions in one task (refund, *then* close
-the ticket), each separately gated; it observes what its action actually returned
-rather than acting blind; and it always gets to report what it did, so the task
-result describes the work instead of stopping mid-sentence at the last side effect.
+Only a result ends a task. An approved call is a step: the tool runs, its result
+folds into history, and the loop re-enters. So one task can take several actions
+(refund, then close the ticket), each gated separately, and the agent sees what each
+call returned before it reports what it did.
 
 `entry` is the only place that stages context and calls the agent; every re-entry
 is "fold in new information, run again." It also owns the `per_run` counters,
@@ -800,68 +751,3 @@ keeping that true — if `boundflow workflow runs <id>` can't inspect a Charter 
 we've built a walled garden. But it isn't part of the product surface, and the
 policy-writing commands should be documented as unsafe against Charter-managed
 workflows.
-
-## Asks of BoundFlow
-
-### Pagination on ListWorkflowRuns
-
-`list_workflow_runs` returns **every** run a workflow has ever had — no `LIMIT` in
-the query, no page token, and nothing trims them. `charter tasks` therefore fetches
-an entire history to show twenty rows, and filters locally.
-
-Fine at ten runs, wrong at ten thousand, and a periodic agent gets there in a
-month. The ask is keyset pagination — `limit` plus an `after` cursor on
-`(created_at, request_id)` — rather than offset, which skips and repeats rows when
-new runs land mid-scan, exactly when you'd be paging. A server-side outcome filter
-would help too: "show me the failures" is the question people actually have.
-
-Related: `WorkflowMetrics` is scoped to the workflow's **current version** while
-the run list spans every version, so after a `set_version` rollback the totals a
-lifecycle rule judges drop to that version's record while the history still shows
-everything. Defensible, but neither is labelled as such.
-
-
-Three related changes, all in the approval path. Together they make the audit log
-self-describing and remove a branch from Charter's state machine.
-
-1. **Persist `justification` into `ApprovalAuditDetails`.** It's written to the job
-   row at `ParkForApproval` and cleared when the decision lands, so the permanent
-   record says "rejected" with no subject.
-2. **Accept an optional `reason` on `approve_workflow` / `reject_workflow`**, stored
-   alongside the decision. Approvals benefit too: "fine, but stop refunding
-   shipping" is the highest-quality signal the system produces and has nowhere to go.
-3. **Surface it on the resumed operation** — `ctx.approval_reason`, beside the
-   existing `ctx.input_answer`. Without this the reason is recorded but Charter must
-   fetch it back over gRPC to use it.
-
-With all three, the rejection path collapses from
-
-```
-rejected -> ask_rejection_reason -> AwaitInput("why?") -> log_rejection_reason -> entry
-```
-
-to `rejected -> entry`, deleting two operations, a second park, a second human
-interaction, and a timeout branch. It also removes a failure mode: today a human
-can reject and walk away, the "why?" input times out, and the agent redrafts having
-learned nothing from a rejection that did happen.
-
-## Open
-
-- **Scheduling.** `WorkflowConfig.repeat_every_seconds` and `triggerable` aren't
-  in any file above. Probably a `schedule:` block in configuration — but a
-  periodic agent can't take per-invocation `inputs`, so the two are mutually
-  exclusive and the schema should say so.
-- **`invoke_mode`.** Derived, not authored: an agent that declares `inputs:` is
-  doing discrete tasks and must be `queue` (coalescing would silently discard a
-  ticket). An agent with no inputs is being told "something changed, go look", and
-  `coalesce` is correct — two such triggers really are one piece of work.
-- **Model pricing.** `set_model_pricing` is per-tenant and global, not per-agent —
-  belongs in `worker.yaml` or a separate tenant-level file, not in an agent's config.
-- **Stranded versions.** A worker registers a handler per `(agent, version)`, so a
-  task pinned to a version no running worker serves is never claimed — it waits,
-  silently, with no error anywhere. The trap is a deploy: roll workers that serve
-  only v2 and every task parked at a gate on v1 is stranded. `serves: versions:
-  [1, 2]` is already the fix and the bundle keeps every version for exactly this,
-  but nothing says when it is safe to drop v1. Wants one question asked of the
-  control plane — are there tasks pinned to versions nobody serves — as a boot
-  warning or a `charter doctor`. Same class as the warnings `apply` already gives.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -204,12 +204,13 @@ apiVersion: charter/v1
 kind: Worker
 
 control_plane:
-  endpoint: ${BOUNDFLOW_SERVER_ADDRESS}
+  endpoint: ${BOUNDFLOW_SERVER_ADDRESS}          # the control API, for the CLI
+  worker_endpoint: ${BOUNDFLOW_WORKER_ADDRESS}   # where workers claim tasks
   api_key: ${BOUNDFLOW_API_KEY}
   tenant: default
 
 llm:
-  provider: anthropic
+  provider: anthropic          # or openai, google_genai, bedrock, ollama, …
   api_key: ${ANTHROPIC_API_KEY}
 
 # Postgres for the harness's own state: checkpoints and the agent's files.
@@ -226,6 +227,25 @@ trace_sink:
   kind: otel
   endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
 ```
+
+Two addresses, because BoundFlow serves the control API and worker dispatch
+separately — on two ports locally, and on two hosts in Cloud. Leave
+`worker_endpoint` out and workers fall back to `BOUNDFLOW_WORKER_ADDRESS`, then to
+localhost, which is right while developing and never right against a remote control
+plane.
+
+`provider` is whatever LangChain can build, so a model it supports works here —
+install that integration and name it. A local runtime needs no `api_key`, and
+`base_url` reaches an OpenAI-compatible server you host. The model must report
+token usage; BoundFlow refuses to run one that doesn't.
+
+`trace_sink` takes every model call and tool call, with its prompts, results and
+token counts, to a sink the worker owns. `otel` speaks OTLP and follows
+OpenTelemetry's GenAI conventions, so Jaeger, Tempo, Datadog and Langfuse read it
+without a translation layer; `jsonl` and `logging` are there for when you just want
+to look. Traces carry prompts, so they go to your backend and never to the control
+plane — which is what makes them different from `store.url`, holding the checkpoints
+and files a parked task resumes from.
 
 At boot the worker loads each listed config version and calls
 `worker.workflow(agent, version=N)` once per version. There is one operation —

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ The worker still runs wherever you put it, so `CHARTER_STORE_URL` is still yours
 Whichever you pick, inference stays yours: the control plane never sees your model
 key or its traffic.
 
-### An agent
+### Your first agent
 
-Two files. `summarize/v1.yaml` is the agent:
+`summarize/v1.yaml`:
 
 ```yaml
 apiVersion: charter/v1
@@ -272,7 +272,7 @@ response_format:
     description: The summary, in two sentences.
 ```
 
-and `worker.yaml` beside it says where to run it:
+`worker.yaml`, beside it:
 
 ```yaml
 apiVersion: charter/v1
@@ -297,10 +297,10 @@ serves:
     versions: [1]
 ```
 
-That agent calls no tools and declares no budget, which is why it fits here. Both
-are optional; the sections below add them.
+It calls no tools and sets no budget. Both are optional, and the sections below
+add them.
 
-### Running it
+### Run it
 
 ```bash
 charter tenant create default        # once per control plane

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charter
 
-**The easiest way to build and manage production-ready agents.**
+**The easiest way to build and manage production-ready agents on your own compute.**
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charter
 
-**The easiest way to build and manage production-ready agents.**
+**Infrastructure for running AI agents in production.**
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
@@ -8,15 +8,9 @@
 > argue with; the code is not settled enough to run anything you care about.
 > Expect the configuration format to change.
 
-Charter is a control plane for AI agents. It turns an agent definition into a
-service you can deploy, govern and roll back.
-
-Define an agent in YAML: what it is responsible for, which tools it may call, what
-needs a human, and what it may spend.
-
-Agents run in your environment. Their state, policy and history live in a control
-plane, so a task survives a closed laptop, a restarted worker, or an approval that
-takes until tomorrow.
+You define an agent and its policies in YAML. Charter runs it on your compute and
+governs it from a persistent control plane, so a run survives a worker restart, a
+deploy, or an approval that takes days.
 
 ## Why Charter
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charter
 
-**The easiest way to build and manage production-ready agents on your own compute.**
+**The easiest way to build and manage production-ready agents that run on your own compute.**
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,82 @@ The worker still runs wherever you put it, so `CHARTER_STORE_URL` is still yours
 Whichever you pick, inference stays yours: the control plane never sees your model
 key or its traffic.
 
-### A project
+### An agent
+
+Two files. `summarize/v1.yaml` is the agent:
+
+```yaml
+apiVersion: charter/v1
+kind: AgentConfig
+
+name: summarize
+version: 1
+model: claude-haiku-4-5
+
+objective: |
+  Summarise this in two sentences: {{ inputs.text }}
+
+inputs:
+  text: { type: string, required: true }
+
+response_format:
+  summary:
+    type: string
+    description: The summary, in two sentences.
+```
+
+and `worker.yaml` beside it says where to run it:
+
+```yaml
+apiVersion: charter/v1
+kind: Worker
+
+control_plane:
+  endpoint: ${BOUNDFLOW_SERVER_ADDRESS}
+  worker_endpoint: ${BOUNDFLOW_WORKER_ADDRESS}
+  api_key: ${BOUNDFLOW_API_KEY}
+  tenant: default
+
+llm:
+  provider: anthropic
+  api_key: ${ANTHROPIC_API_KEY}
+
+store:
+  url: ${CHARTER_STORE_URL}
+
+agents_dir: ./
+serves:
+  - agent: summarize
+    versions: [1]
+```
+
+That agent calls no tools and declares no budget, which is why it fits here. Both
+are optional; the sections below add them.
+
+### Running it
+
+```bash
+charter tenant create default        # once per control plane
+charter agent create summarize       # prints an instance id
+charter apply .                      # arm config and policy
+charter worker .                     # in its own terminal — this is the process
+```
+
+Then, from another terminal:
+
+```bash
+charter run summarize --instance <id> --text "..."
+charter status <task-id>
+```
+
+`create` is separate from `apply` because an instance owns state — its own store,
+budget and lifecycle history — so bringing one into existence is a decision a
+person makes, not something CI does on its behalf. `apply` is safe to re-run.
+
+Every command that acts on an agent names an instance, including when there is
+only one: the instance is what holds the state.
+
+### A larger project
 
 ```
 .
@@ -343,26 +418,13 @@ model traffic never reaches the control plane. The CLI reads this same file, so
 the control plane is configured once and every command talks to the one your
 worker does.
 
-### First run
+### Something that runs end to end
 
-```bash
-charter validate .                    # parse and cross-check every file
-charter agent create leads-finder     # bring one instance into existence
-charter apply .                       # arm config, policy and pricing
-charter worker .                      # in its own terminal — this is the process
-```
-
-`create` is separate from `apply` because an instance owns state — its own store,
-budget and lifecycle history — so bringing one into existence is a decision a
-person makes, not something CI does on their behalf. `apply` is safe to re-run as
-often as you like.
-
-`create` prints an instance id; keep it. Commands that act on an agent name an
-instance, because the instance is the thing holding the state:
-
-```bash
-charter run leads-finder --instance a3f9c012 --topic "..."
-```
+[demo/leads/](demo/leads/) is an agent that finds people, asks you to approve every
+message before it sends one, and waits — for days if that is how long you take. It
+runs against a fake network on your machine, so nothing reaches anybody.
+[examples/](examples/) has fuller configurations for reference; those name real
+Zendesk and Stripe servers, so they read rather than run.
 
 ### Deploying
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charter
 
-**The easiest way to build and manage production-ready agents that run on your own compute.**
+**Build and manage production-ready agents that run on your own compute.**
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
@@ -14,20 +14,18 @@ from a persistent control plane.
 
 ## Why Charter
 
-- **Automatic rollback.** Set thresholds on failures, spend and rejections. An
-  agent that crosses one pauses, cools down, or returns to the version that worked.
-- **Durable approvals.** A run parks at a gate and resumes days later, on another
-  worker, with everything it had discovered, spent and been told.
-- **Fleet visibility.** Every agent you run is listed in `charter agents` and in
-  the console, with what it is waiting on, what it has spent, and what stopped it.
-- **Per-task budgets.** Cap cost, model calls and tool failures for a whole task.
-  An exhausted limit reports which one it was.
-- **Declared authority.** The model sees only the tools you list. Gated tools it
-  can propose, but not call.
-- **Versioned behaviour.** Objective, tools and gates are an immutable file, so a
-  rollback restores the whole agent rather than a prompt string.
-- **Traces you own.** Send every model and tool call to your own OTLP backend.
-  Prompts never reach the control plane.
+- **Durable execution.** A run parks for a human and resumes days later on another
+  worker, with its state intact.
+- **Policy that acts.** Set thresholds on the metrics an agent produces. One that
+  crosses a threshold pauses, cools down, or rolls back to the version that worked.
+- **Declared authority.** The model sees only the tools you list, gated tools
+  require human approval, and budgets cap what a task may spend.
+- **Fleet operations.** Every agent's operational state, run history, metrics and
+  open decisions, from the CLI or the console.
+- **Your network, your data.** Workers run in your environment, so agents reach
+  internal services and databases directly. Model keys and prompts never reach the
+  control plane, and the agent's conversation, files and traces stay in stores you
+  run.
 
 [DESIGN.md](DESIGN.md) documents every field.
 
@@ -125,7 +123,7 @@ add them.
 charter tenant create default        # once per control plane
 charter agent create summarize       # prints an instance id
 charter apply .                      # arm config and policy
-charter worker .                     # in its own terminal — this is the process
+charter worker .                     # leave this running, it is the process
 ```
 
 Then, from another terminal:
@@ -195,13 +193,13 @@ through their workers and the control plane whether or not the CLI is installed.
 
 ## Documentation
 
-- [DESIGN.md](DESIGN.md) — every field of every file, and the decisions behind them
-- [demo/leads/](demo/leads/) — an agent that finds people, asks you to approve
+- [DESIGN.md](DESIGN.md): every field of every file, and the decisions behind them
+- [demo/leads/](demo/leads/): an agent that finds people, asks you to approve
   every message before it sends one, and waits days if that is how long you take.
   It runs against a fake network on your machine, so nothing reaches anybody.
-- [examples/](examples/) — fuller configurations, for reading. They name real
+- [examples/](examples/): fuller configurations, for reading. They name real
   Zendesk and Stripe servers, so they do not run as-is.
-- [deploy/](deploy/) — running workers as containers, and a control plane locally
+- [deploy/](deploy/): running workers as containers, and a control plane locally
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Define an agent in YAML: what it is responsible for, which tools it may call, wh
 needs a human, and what it may spend. Charter deploys it as a service you can
 operate.
 
-The agent runs in your environment. Its state, policy and history live in a control
+Agents run in your environment. Their state, policy and history live in a control
 plane, so a task survives a closed laptop, a restarted worker, or an approval that
-takes until tomorrow.
+takes until tomorrow — and one console covers all of them, whether you run three or
+three hundred.
 
 ## Why Charter
 
@@ -22,6 +23,8 @@ takes until tomorrow.
   agent that crosses one pauses, cools down, or returns to the version that worked.
 - **Durable approvals.** A run parks at a gate and resumes days later, on another
   worker, with everything it had discovered, spent and been told.
+- **One console for the fleet.** `charter ui` and `charter agents` show every agent
+  you run, what each is waiting on, what it has spent, and what stopped it.
 - **Per-task budgets.** Cap cost, model calls and tool failures for a whole task.
   An exhausted limit reports which one it was.
 - **Declared authority.** The model sees only the tools you list. Gated tools it

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 
 Charter provides the infrastructure for running AI agents in production. You define
 an agent and its policies in YAML. Charter runs it on your compute and governs it
-from a persistent control plane, so a run survives a worker restart, a deploy, or an
-approval that takes days.
+from a persistent control plane.
 
 ## Why Charter
 

--- a/README.md
+++ b/README.md
@@ -88,19 +88,44 @@ meantime.
 
 ## What makes it production-ready
 
-### Explicit authority
+### It pauses and rolls itself back
 
-Access to an MCP server is not access to everything that server exposes. The
-model only ever sees the tools you declared:
+Lifecycle rules watch an agent's own cost, failures and rejections, and act on
+them without you:
 
+```yaml
+rules:
+  - when: { metric: num_failures, threshold: 2 }
+    then: { pause: { window: 5 } }
+
+  - when: { metric: cost, threshold: 5.00 }
+    then: { cooldown: { window: 20, seconds: 300 } }
+
+  - when: { metric: approval_rejections, threshold: 3 }
+    then: { set_version: { target: 1 } }
 ```
-mcp stripe: 34 tools available, 2 declared (32 ignored)
+
+A noisy agent gets cooled down. A repeatedly failing one gets paused. A new
+version whose decisions keep getting rejected rolls back to the one that worked —
+and because versions are immutable specifications, rollback restores the whole
+agent, not just a prompt string. What changed is a file in Git, with an author and
+a diff.
+
+### An approval that waits as long as it takes
+
+An agent stops for a human for two reasons: it needs information it shouldn't
+guess, or it wants to do something beyond its authority.
+
+```bash
+charter pending refund-triage
+charter approve apr_01J8Z --reason "confirmed duplicate"
+charter answer  inp_01J8Z "use the March charge"
 ```
 
-If the server adds a tool tomorrow, your agent doesn't silently gain a capability.
-And tools marked `approval: always` aren't callable inside the agent loop at all —
-the agent can propose them, but a separate step executes them after a human signs
-off. The model can propose authority it doesn't have; it can't grant it to itself.
+Neither is a process sitting around waiting. Charter checkpoints the task; it can
+wait overnight and resume on another worker with everything it had discovered,
+spent and been told. Rejection carries a reason back to the agent, so a "no" is
+feedback it can act on, not just a closed door.
 
 ### A budget per task
 
@@ -120,43 +145,19 @@ stripe__create_refund failed 3 times (max_tool_failures=3)
 the integration looks broken
 ```
 
-### Humans in the loop, durably
+### It only has the tools you gave it
 
-An agent stops for a human for two reasons: it needs information it shouldn't
-guess, or it wants to do something beyond its authority.
+Access to an MCP server is not access to everything that server exposes. The
+model only ever sees the tools you declared:
 
-```bash
-charter pending refund-triage
-charter approve apr_01J8Z --reason "confirmed duplicate"
-charter answer  inp_01J8Z "use the March charge"
+```
+mcp stripe: 34 tools available, 2 declared (32 ignored)
 ```
 
-Neither is a process sitting around waiting. Charter checkpoints the task; it can
-wait overnight and resume on another worker with everything it had discovered,
-spent and been told. Rejection carries a reason back to the agent, so a "no" is
-feedback it can act on, not just a closed door.
-
-### Policy that acts on its own
-
-Humans govern individual actions. Lifecycle rules govern the agent itself:
-
-```yaml
-rules:
-  - when: { metric: num_failures, threshold: 2 }
-    then: { pause: { window: 5 } }
-
-  - when: { metric: cost, threshold: 5.00 }
-    then: { cooldown: { window: 20, seconds: 300 } }
-
-  - when: { metric: approval_rejections, threshold: 3 }
-    then: { set_version: { target: 1 } }
-```
-
-A noisy agent gets cooled down. A repeatedly failing one gets paused. A new
-version whose decisions keep getting rejected rolls back to the one that worked —
-and because versions are immutable specifications, rollback restores the whole
-agent, not just a prompt string. What changed is a file in Git, with an author and
-a diff.
+If the server adds a tool tomorrow, your agent doesn't silently gain a capability.
+And tools marked `approval: always` aren't callable inside the agent loop at all —
+the agent can propose them, but a separate step executes them after a human signs
+off. The model can propose authority it doesn't have; it can't grant it to itself.
 
 ## Operate agents, not sessions
 

--- a/README.md
+++ b/README.md
@@ -316,13 +316,6 @@ charter run summarize --instance <id> --text "..."
 charter status <task-id>
 ```
 
-`create` is separate from `apply` because an instance owns state — its own store,
-budget and lifecycle history — so bringing one into existence is a decision a
-person makes, not something CI does on its behalf. `apply` is safe to re-run.
-
-Every command that acts on an agent names an instance, including when there is
-only one: the instance is what holds the state.
-
 ### A larger project
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charter
 
-**Infrastructure for running AI agents in production.**
+**The easiest way to build and manage production-ready agents.**
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
@@ -8,9 +8,10 @@
 > argue with. The code is not settled enough to run anything you care about.
 > Expect the configuration format to change.
 
-You define an agent and its policies in YAML. Charter runs it on your compute and
-governs it from a persistent control plane, so a run survives a worker restart, a
-deploy, or an approval that takes days.
+Charter provides the infrastructure for running AI agents in production. You define
+an agent and its policies in YAML. Charter runs it on your compute and governs it
+from a persistent control plane, so a run survives a worker restart, a deploy, or an
+approval that takes days.
 
 ## Why Charter
 

--- a/README.md
+++ b/README.md
@@ -21,198 +21,24 @@ The agent runs in your environment. Its state, policy and history live in a
 control plane, so a task survives a closed laptop, a restarted worker, or an
 approval that takes until tomorrow.
 
-> [!WARNING]
-> **Pre-alpha.** Charter agents have run end-to-end against a live control plane,
-> a real model and real MCP servers — but plenty hasn't. Expect rough edges and
-> expect the configuration format to change.
+## Why Charter
 
-## Define an agent
+- **Automatic rollback** — an agent whose failures, spend or rejections cross a
+  threshold you set pauses, cools down, or returns to the version that worked.
+- **Durable approvals** — a run parks at a gate and resumes days later, on another
+  worker, with everything it had discovered, spent and been told.
+- **Per-task budgets** — cost, model calls and tool failures are capped across the
+  whole task, and an exhausted limit names which one and what it suggests.
+- **Declared authority** — the model sees only the tools you listed, and the ones
+  you gate it can propose but never call.
+- **Versioned behaviour** — objective, tools and gates are an immutable file, so a
+  rollback restores the whole agent rather than a prompt string.
+- **Traces you own** — every model and tool call to your own OTLP backend; prompts
+  never reach the control plane.
 
-An agent is a directory with a version file in it — `refund-triage/v1.yaml`:
+Each is a few lines of YAML. [DESIGN.md](DESIGN.md) is the field reference.
 
-```yaml
-apiVersion: charter/v1
-kind: AgentConfig
-
-name: refund-triage
-version: 1
-model: claude-haiku-4-5
-
-objective: |
-  Resolve the refund request on ticket {{ inputs.ticket_id }}.
-  Look up the ticket and the charge before proposing anything.
-  Never propose a refund above ${{ inputs.max_refund_usd }}.
-
-inputs:
-  ticket_id: { type: string, required: true }
-  max_refund_usd: { type: number, default: 100 }
-
-mcp:
-  - name: stripe
-    url: https://mcp.stripe.com
-    env: [STRIPE_API_KEY]
-    tools:
-      - tool: get_charge
-      - tool: create_refund
-        approval: always
-
-response_format:
-  resolution: { type: string }
-  refunded_usd: { type: number }
-```
-
-That file is the whole agent. Budgets and lifecycle rules live in two optional
-files beside it — see [a project](#a-project) — and a conservative default
-ceiling applies until you add them.
-
-Deploy it, create an instance, and give it work:
-
-```bash
-charter agent create refund-triage
-charter apply .
-charter run refund-triage --instance a3f9c012 --ticket-id 4821
-```
-
-Suppose the agent reads the ticket and the charge and concludes a $240 refund is
-warranted. It cannot issue it. `create_refund` requires approval, so Charter
-parks the task and surfaces the proposed action and the agent's reasoning to a
-human:
-
-```bash
-charter approve apr_01J8Z --reason "third dispute this month"
-```
-
-Only then is the refund executed. The agent receives the result, finishes the
-task, and reports what happened. The task didn't live in your terminal in the
-meantime.
-
-## What makes it production-ready
-
-### It pauses and rolls itself back
-
-Lifecycle rules watch an agent's own cost, failures and rejections, and act on
-them without you:
-
-```yaml
-rules:
-  - when: { metric: num_failures, threshold: 2 }
-    then: { pause: { window: 5 } }
-
-  - when: { metric: cost, threshold: 5.00 }
-    then: { cooldown: { window: 20, seconds: 300 } }
-
-  - when: { metric: approval_rejections, threshold: 3 }
-    then: { set_version: { target: 1 } }
-```
-
-A noisy agent gets cooled down. A repeatedly failing one gets paused. A new
-version whose decisions keep getting rejected rolls back to the one that worked —
-and because versions are immutable specifications, rollback restores the whole
-agent, not just a prompt string. What changed is a file in Git, with an author and
-a diff.
-
-### An approval that waits as long as it takes
-
-An agent stops for a human for two reasons: it needs information it shouldn't
-guess, or it wants to do something beyond its authority.
-
-```bash
-charter pending refund-triage
-charter approve apr_01J8Z --reason "confirmed duplicate"
-charter answer  inp_01J8Z "use the March charge"
-```
-
-Neither is a process sitting around waiting. Charter checkpoints the task; it can
-wait overnight and resume on another worker with everything it had discovered,
-spent and been told. Rejection carries a reason back to the agent, so a "no" is
-feedback it can act on, not just a closed door.
-
-### A budget per task
-
-```yaml
-per_run:
-  max_cost_usd: 0.30
-  max_llm_calls: 40
-  max_tool_failures: 3
-```
-
-Limits hold across the whole task — reasoning rounds, retries, human feedback and
-tool calls alike. When one is exhausted, Charter tells you the operational reason
-rather than collapsing it into a generic failure:
-
-```
-stripe__create_refund failed 3 times (max_tool_failures=3)
-the integration looks broken
-```
-
-### It only has the tools you gave it
-
-Access to an MCP server is not access to everything that server exposes. The
-model only ever sees the tools you declared:
-
-```
-mcp stripe: 34 tools available, 2 declared (32 ignored)
-```
-
-If the server adds a tool tomorrow, your agent doesn't silently gain a capability.
-And tools marked `approval: always` aren't callable inside the agent loop at all —
-the agent can propose them, but a separate step executes them after a human signs
-off. The model can propose authority it doesn't have; it can't grant it to itself.
-
-## Operate agents, not sessions
-
-An agent persists beyond any single task.
-
-```
-$ charter agents
-
-AGENT           VER  STATUS  ACTIVITY
-invoice-chaser  v1   paused  idle
-refund-triage   v1   active  awaiting_approval
-ticket-sweeper  v1   active  idle
-```
-
-Inspect its authority and how close it is to tripping a rule:
-
-```
-$ charter describe refund-triage
-
-limits per task
-  max_cost_usd    0.25
-  max_llm_calls   20
-
-rules
-  num_failures   1 of 2     -> pause window=5
-  cost           5.2 of 5   -> cooldown window=20 seconds=300
-```
-
-And reconstruct, afterwards, every governance decision that was made:
-
-```
-$ charter audit refund-triage
-
-2026-08-18 03:47  approval rejected by dana@example.com
-                  refund-triage: run stripe__create_refund
-                  amount_usd: 240
-                  reason: wrong charge — ch_9001 is the original
-```
-
-## Getting started
-
-1. **Define the agent** — `v1.yaml`: its objective, the tools it may call, which of
-   them need a human.
-2. **Set its policy** — `runtime.yaml` for budgets and authority, `lifecycle.yaml`
-   for pause, cooldown and rollback rules.
-3. **Package it** — `charter push` seals the version into your registry. Skip it
-   while developing: a worker reads a directory just as well.
-4. **Configure a worker** — `worker.yaml`: credentials, and which agents and
-   versions this process serves.
-5. **Apply it** — `charter apply` arms config and policy on the control plane;
-   `charter agent create` instantiates the agent.
-6. **Run it** — `charter run` starts a task; `charter status` says how it went.
-7. **Manage it** — the step that doesn't end: approve what it proposes, watch what
-   it spends, add a `v2.yaml` when it should behave differently. `charter ui` puts
-   the same thing in a browser, for whoever decides an approval.
+## Quickstart
 
 ```bash
 pip install boundflow-charter          # add [ui] for the console, [otel] for traces
@@ -317,161 +143,36 @@ charter run summarize --instance <id> --text "..."
 charter status <task-id>
 ```
 
-### A larger project
+## How it works
 
-```
-.
-├── worker.yaml               # which agents this worker serves, pricing, channels
-└── leads-finder/
-    ├── v1.yaml               # objective, tools, gates — versioned, immutable
-    ├── v1/skills/            # procedures for that version, shipped with it
-    ├── runtime.yaml          # budgets, limits, authority — policy, not versioned
-    └── lifecycle.yaml        # pause, cooldown and rollback rules
-```
-
-Only `v1.yaml` is required; a version file plus credentials is enough to run an
-agent. The split matters: `v1.yaml` is what the agent *does* and is versioned, so
-a rollback restores behavior. Budgets and lifecycle rules are today's guardrails
-and stay in force across one.
-
-Skills are the procedures the agent should follow once it gets there — how your
-refunds policy works, the runbook a new hire would be handed. Drop them in
-`v1/skills/<name>/SKILL.md` and they ship with that version; the layout is
-deepagents' own, so skills you already have work unchanged. They live inside `v1/`
-because rolling back to v1 should restore the instructions v1 was running with.
-
-### Traces
-
-Every model call and tool call, with its prompts, results and token counts, goes to
-a sink the worker owns:
+An agent is a directory with a version file in it. That file says what the agent is
+for, which tools it may call, and which of them stop for a person:
 
 ```yaml
-trace_sink:
-  kind: otel
-  endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT}
+mcp:
+  - name: stripe
+    url: https://mcp.stripe.com
+    env: [STRIPE_API_KEY]
+    tools:
+      - tool: get_charge
+      - tool: create_refund
+        approval: always
 ```
 
-`otel` speaks OTLP and follows OpenTelemetry's GenAI conventions, so Jaeger, Tempo,
-Datadog and Langfuse all read it without a translation layer — `jsonl` and
-`logging` are there for when you just want to look. Traces are captured worker-side
-and carry prompts, so they go to your backend and never to the control plane.
-
-That is separate from `store.url`, which holds checkpoints and the agent's files —
-state a parked task resumes from, not telemetry.
-
-### Which agents a worker serves
-
-```yaml
-serves:
-  - agent: leads-finder       # from ./leads-finder, while you develop
-    versions: [1]
-  - agent: refund-triage      # from the registry, once it is real
-    versions: [1, 2]
-    repository: ghcr.io/acme/agents
-```
-
-A repository derives one address per version — `<repository>/<agent>:v<N>`, the
-address `charter push` writes. List every version a lifecycle rule can roll back
-to: a worker that cannot build the old version leaves the control plane
-dispatching work nobody can handle.
-
-### Credentials
-
-`worker.yaml` is committed, so nothing secret goes in it. Credentials are `${VAR}`
-references resolved from the environment when the worker starts:
-
-```yaml
-control_plane:
-  endpoint: ${BOUNDFLOW_SERVER_ADDRESS}          # the control API, for the CLI
-  worker_endpoint: ${BOUNDFLOW_WORKER_ADDRESS}   # where workers claim tasks
-  api_key: ${BOUNDFLOW_API_KEY}
-  tenant: default
-
-llm:
-  provider: anthropic          # or openai, google_genai, bedrock, ollama, …
-  api_key: ${ANTHROPIC_API_KEY}
-
-store:
-  url: ${CHARTER_STORE_URL}
-```
-
-Two addresses, because BoundFlow serves the control API and worker dispatch
-separately — on two ports locally, and on two hosts in Cloud. Leave
-`worker_endpoint` out and workers fall back to `BOUNDFLOW_WORKER_ADDRESS`, then to
-localhost, which is what you want while developing and never what you want against
-a remote control plane.
-
-`provider` is whatever LangChain can build, so a model it supports works here —
-install that integration (`pip install "boundflow-charter[openai]"`) and name it.
-A local runtime needs no `api_key`, and `base_url` reaches an OpenAI-compatible
-server you host. The one requirement is that the model reports token usage:
-BoundFlow refuses to run one that doesn't.
-
-Inference is bring-your-own: your model key stays in the worker environment and
-model traffic never reaches the control plane. The CLI reads this same file, so
-the control plane is configured once and every command talks to the one your
-worker does.
-
-### Something that runs end to end
-
-[demo/leads/](demo/leads/) is an agent that finds people, asks you to approve every
-message before it sends one, and waits — for days if that is how long you take. It
-runs against a fake network on your machine, so nothing reaches anybody.
-[examples/](examples/) has fuller configurations for reference; those name real
-Zendesk and Stripe servers, so they read rather than run.
-
-### Deploying
-
-Locally, `charter worker .` is the whole thing, which is what you want while
-iterating — the agent's MCP servers and your logs are right in front of you.
-
-For anything long-lived, run the worker as a container. The reason is isolation
-rather than packaging: an agent can declare MCP servers as commands, and the
-worker executes them. [deploy/](deploy/) has a Dockerfile that mounts the project
-rather than baking it in, so changing an objective is a restart, not a rebuild.
-
-## CLI
-
-Working with configuration:
+Suppose the agent reads a ticket and concludes a $240 refund is warranted. It
+cannot issue it. `create_refund` requires approval, so Charter parks the task and
+surfaces the proposed call and the agent's reasoning to a human:
 
 ```bash
-charter validate .               # parse and cross-check configuration
-charter diff .                   # compare declared and deployed state
-charter apply .                  # update config, policy and pricing
-charter push <agent> <ref>       # publish a version to an OCI registry
-charter worker .                 # run agents in this environment
+charter approve apr_01J8Z --reason "third dispute this month"
 ```
 
-Operating an agent:
-
-```bash
-charter agent create <agent>     # bring an instance into existence
-charter run <agent> --flags      # start a task
-charter agents                   # every agent and what it's doing
-charter describe <agent>         # authority, limits, rules, any hold
-charter tasks <agent>            # task history
-charter status <task-id>         # result, cost and why it stopped
-charter audit <agent>            # every governance decision recorded
-
-charter pending <agent>          # the open gate, if it's parked on one
-charter approve / reject / answer <id>
-charter ui                       # the same, in a browser
-
-charter pause <agent>            # stop it taking work
-charter resume <agent> --suspension <id>
-charter agent delete <agent>     # destroy an instance and its history
-```
-
-Read commands take `--json` for the complete record instead of the curated view.
-
-## Architecture
-
-Charter is an opinionated agent layer built on
-[BoundFlow](https://github.com/boundflow/boundflow).
-
-`charter apply` compiles your configuration into workflows and policy on the
-BoundFlow control plane. Charter workers run the actual agent loop in your
-environment, talking to your MCP servers with credentials that never leave it.
+Only then is the refund executed. The agent receives the result, finishes the task,
+and reports what happened. The task didn't live in your terminal in the meantime —
+`charter apply` compiled your configuration into workflows and policy on the
+[BoundFlow](https://github.com/boundflow/boundflow) control plane, and a Charter
+worker runs the agent loop in your environment, talking to your MCP servers with
+credentials that never leave it.
 
 ```
                     BoundFlow
@@ -494,8 +195,15 @@ environment, talking to your MCP servers with credentials that never leave it.
 Charter introduces no database or service of its own. If the Charter CLI vanished,
 deployed agents would keep running through their workers and the control plane.
 
-See [DESIGN.md](DESIGN.md) for the full configuration reference and the design
-decisions behind it, and [examples/](examples/) for complete configurations.
+## Documentation
+
+- [DESIGN.md](DESIGN.md) — every field of every file, and the decisions behind them
+- [demo/leads/](demo/leads/) — an agent that finds people, asks you to approve
+  every message before it sends one, and waits days if that is how long you take.
+  It runs against a fake network on your machine, so nothing reaches anybody.
+- [examples/](examples/) — fuller configurations, for reading. They name real
+  Zendesk and Stripe servers, so they do not run as-is.
+- [deploy/](deploy/) — running workers as containers, and a control plane locally
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
 > **Pre-alpha, and in the open early.** The design is settled enough to read and
-> argue with; the code is not settled enough to run anything you care about.
+> argue with. The code is not settled enough to run anything you care about.
 > Expect the configuration format to change.
 
 You define an agent and its policies in YAML. Charter runs it on your compute and
@@ -211,8 +211,8 @@ python -m venv .venv
 .venv/bin/pytest
 ```
 
-`boundflow` comes from PyPI; add `--pre --upgrade boundflow` to track its main, which
-is what CI's second unit job does.
+`boundflow` comes from PyPI. Add `--pre --upgrade boundflow` to track its main,
+which is what CI's second unit job does.
 
 End-to-end tests need a control plane, and skip themselves without one. The compose
 file CI uses runs the published image:

--- a/README.md
+++ b/README.md
@@ -145,8 +145,7 @@ charter status <task-id>
 
 ## How it works
 
-An agent is a directory with a version file in it. That file says what the agent is
-for, which tools it may call, and which of them stop for a person:
+A tool the agent shouldn't call on its own gets one line:
 
 ```yaml
 mcp:

--- a/README.md
+++ b/README.md
@@ -8,35 +8,30 @@
 > argue with; the code is not settled enough to run anything you care about.
 > Expect the configuration format to change.
 
-A prototype agent is a prompt and some tools. A production agent needs more: a
-defined responsibility, explicit authority over what it may touch, a budget it
-can't exceed, a way for humans to intervene while it works, and someone watching
-its behavior over time.
+Define an agent in YAML: what it is responsible for, which tools it may call, what
+needs a human, and what it may spend. Charter deploys it as a service you can
+operate.
 
-Charter is that, as configuration. You describe an agent in YAML — what it's
-responsible for, which tools it gets, what needs a human, what it may spend — and
-Charter deploys it as a durable, governed service you can operate.
-
-The agent runs in your environment. Its state, policy and history live in a
-control plane, so a task survives a closed laptop, a restarted worker, or an
-approval that takes until tomorrow.
+The agent runs in your environment. Its state, policy and history live in a control
+plane, so a task survives a closed laptop, a restarted worker, or an approval that
+takes until tomorrow.
 
 ## Why Charter
 
-- **Automatic rollback** — an agent whose failures, spend or rejections cross a
-  threshold you set pauses, cools down, or returns to the version that worked.
-- **Durable approvals** — a run parks at a gate and resumes days later, on another
+- **Automatic rollback.** Set thresholds on failures, spend and rejections. An
+  agent that crosses one pauses, cools down, or returns to the version that worked.
+- **Durable approvals.** A run parks at a gate and resumes days later, on another
   worker, with everything it had discovered, spent and been told.
-- **Per-task budgets** — cost, model calls and tool failures are capped across the
-  whole task, and an exhausted limit names which one and what it suggests.
-- **Declared authority** — the model sees only the tools you listed, and the ones
-  you gate it can propose but never call.
-- **Versioned behaviour** — objective, tools and gates are an immutable file, so a
+- **Per-task budgets.** Cap cost, model calls and tool failures for a whole task.
+  An exhausted limit reports which one it was.
+- **Declared authority.** The model sees only the tools you list. Gated tools it
+  can propose, but not call.
+- **Versioned behaviour.** Objective, tools and gates are an immutable file, so a
   rollback restores the whole agent rather than a prompt string.
-- **Traces you own** — every model and tool call to your own OTLP backend; prompts
-  never reach the control plane.
+- **Traces you own.** Send every model and tool call to your own OTLP backend.
+  Prompts never reach the control plane.
 
-Each is a few lines of YAML. [DESIGN.md](DESIGN.md) is the field reference.
+[DESIGN.md](DESIGN.md) documents every field.
 
 ## Quickstart
 
@@ -65,15 +60,14 @@ export CHARTER_STORE_URL=postgres://charter:charter@localhost:5434/charter
 
 Remove it with `docker compose -f deploy/local.compose.yml down -v`.
 
-For production, either run the BoundFlow backend yourself — its
-[deployment docs](https://github.com/boundflow/boundflow/blob/main/docs/deployment.md)
-own that — or use **BoundFlow Cloud**, managed and in early access
-([request access](mailto:hello@boundflow.dev)). Cloud hands you an API key and the
-two addresses; export those instead of the local ones and nothing else changes.
-The worker still runs wherever you put it, so `CHARTER_STORE_URL` is still yours.
+For production you have two options. Run the BoundFlow backend yourself, following
+its [deployment docs](https://github.com/boundflow/boundflow/blob/main/docs/deployment.md).
+Or use **BoundFlow Cloud**, which is managed and in early access
+([request access](mailto:hello@boundflow.dev)): it gives you an API key and the two
+addresses, and you export those instead of the local ones. The worker still runs
+wherever you put it, so `CHARTER_STORE_URL` stays yours.
 
-Whichever you pick, inference stays yours: the control plane never sees your model
-key or its traffic.
+Either way the control plane never sees your model key or its traffic.
 
 ### Your first agent
 
@@ -158,20 +152,21 @@ mcp:
         approval: always
 ```
 
-Suppose the agent reads a ticket and concludes a $240 refund is warranted. It
-cannot issue it. `create_refund` requires approval, so Charter parks the task and
-surfaces the proposed call and the agent's reasoning to a human:
+When the agent decides to call `create_refund`, Charter stops the task and shows a
+human the call it wants to make and the reasoning behind it:
 
 ```bash
 charter approve apr_01J8Z --reason "third dispute this month"
 ```
 
-Only then is the refund executed. The agent receives the result, finishes the task,
-and reports what happened. The task didn't live in your terminal in the meantime —
-`charter apply` compiled your configuration into workflows and policy on the
-[BoundFlow](https://github.com/boundflow/boundflow) control plane, and a Charter
-worker runs the agent loop in your environment, talking to your MCP servers with
-credentials that never leave it.
+The refund runs after you approve it. The agent gets the result, finishes the task,
+and reports what it did.
+
+Nothing waited in your terminal for that. `charter apply` compiles your
+configuration into workflows and policy on the
+[BoundFlow](https://github.com/boundflow/boundflow) control plane. A Charter worker
+runs the agent loop in your environment and talks to your MCP servers with
+credentials that stay there.
 
 ```
                     BoundFlow
@@ -191,8 +186,8 @@ credentials that never leave it.
         └─────────────────────────┘
 ```
 
-Charter introduces no database or service of its own. If the Charter CLI vanished,
-deployed agents would keep running through their workers and the control plane.
+Charter adds no database or service of its own. Deployed agents keep running
+through their workers and the control plane whether or not the CLI is installed.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ operate.
 
 Agents run in your environment. Their state, policy and history live in a control
 plane, so a task survives a closed laptop, a restarted worker, or an approval that
-takes until tomorrow — and one console covers all of them, whether you run three or
-three hundred.
+takes until tomorrow.
 
 ## Why Charter
 
@@ -23,8 +22,8 @@ three hundred.
   agent that crosses one pauses, cools down, or returns to the version that worked.
 - **Durable approvals.** A run parks at a gate and resumes days later, on another
   worker, with everything it had discovered, spent and been told.
-- **One console for the fleet.** `charter ui` and `charter agents` show every agent
-  you run, what each is waiting on, what it has spent, and what stopped it.
+- **Fleet visibility.** Every agent you run is listed in `charter agents` and in
+  the console, with what it is waiting on, what it has spent, and what stopped it.
 - **Per-task budgets.** Cap cost, model calls and tool failures for a whole task.
   An exhausted limit reports which one it was.
 - **Declared authority.** The model sees only the tools you list. Gated tools it

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 > argue with; the code is not settled enough to run anything you care about.
 > Expect the configuration format to change.
 
+Charter is a control plane for AI agents. It turns an agent definition into a
+service you can deploy, govern and roll back.
+
 Define an agent in YAML: what it is responsible for, which tools it may call, what
-needs a human, and what it may spend. Charter deploys it as a service you can
-operate.
+needs a human, and what it may spend.
 
 Agents run in your environment. Their state, policy and history live in a control
 plane, so a task survives a closed laptop, a restarted worker, or an approval that
@@ -167,8 +169,14 @@ and reports what it did.
 Nothing waited in your terminal for that. `charter apply` compiles your
 configuration into workflows and policy on the
 [BoundFlow](https://github.com/boundflow/boundflow) control plane. A Charter worker
-runs the agent loop in your environment and talks to your MCP servers with
-credentials that stay there.
+runs the agent in your environment and talks to your MCP servers with credentials
+that stay there.
+
+The agent loop itself is [deepagents](https://github.com/langchain-ai/deepagents),
+so its tools, subagents, filesystem and skills work here unchanged. Charter makes
+that loop durable and governed: it checkpoints the run, turns the harness's
+interrupts into approvals a person can answer tomorrow, and holds it to the limits
+your config declares.
 
 ```
                     BoundFlow

--- a/demo/leads/README.md
+++ b/demo/leads/README.md
@@ -58,19 +58,31 @@ on a timer, which is the only way to see an agent genuinely wait on a person.
 
 ## Running it
 
-Four environment variables — the control plane, its key, Postgres for the
-harness's own state, and a model key:
+Activate the virtualenv Charter is installed in, rather than calling its `charter`
+by path. The agent declares its tool server as `command: python`, so the worker
+spawns whatever `python` is on PATH — without the venv active that interpreter has
+no `mcp`, and `leads-finder` quarantines at boot saying so.
+
+    source .venv/bin/activate
+
+Six environment variables — the control plane's two addresses, its key, the tenant,
+Postgres for the harness's own state, and a model key:
 
     export BOUNDFLOW_SERVER_ADDRESS=http://localhost:50051
     export BOUNDFLOW_WORKER_ADDRESS=http://localhost:50052
     export BOUNDFLOW_API_KEY=...
+    export CHARTER_TENANT=default
     export CHARTER_STORE_URL=postgres://...
     export ANTHROPIC_API_KEY=...
-    export CHARTER_TENANT=default
 
-Create the instances, then start the worker from this directory — the MCP server
-is spawned as a subprocess relative to wherever the worker runs:
+If you brought the control plane up with `deploy/local.compose.yml`, the store is
+`postgres://charter:charter@localhost:5434/charter`.
 
+The tenant has to exist before an agent can live in it. Create it once, then the
+instances, then start the worker from this directory — the MCP server is spawned
+as a subprocess relative to wherever the worker runs:
+
+    charter tenant create default                         # once per control plane
     charter agent create leads-finder --path demo/leads   # prints an instance id
     charter apply demo/leads/worker.yaml --all
 

--- a/demo/leads/README.md
+++ b/demo/leads/README.md
@@ -58,12 +58,8 @@ on a timer, which is the only way to see an agent genuinely wait on a person.
 
 ## Running it
 
-Activate the virtualenv Charter is installed in, rather than calling its `charter`
-by path. The agent declares its tool server as `command: python`, so the worker
-spawns whatever `python` is on PATH — without the venv active that interpreter has
-no `mcp`, and `leads-finder` quarantines at boot saying so.
-
-    source .venv/bin/activate
+Run these with Charter's environment active — the agent spawns its tool server as
+`python network.py`, and it needs the interpreter Charter is installed in.
 
 Six environment variables — the control plane's two addresses, its key, the tenant,
 Postgres for the harness's own state, and a model key:

--- a/demo/leads/README.md
+++ b/demo/leads/README.md
@@ -33,7 +33,7 @@ Every field the schema accepts appears in those four YAML files. Anything the de
 doesn't use is commented rather than omitted, so the file is the reference.
 
 **Which half goes where.** `charter push` seals `v1.yaml` + `v1/skills/` into an
-artifact; `charter apply` sends `runtime.yaml` and `lifecycle.yaml` to the control
+artifact. `charter apply` sends `runtime.yaml` and `lifecycle.yaml` to the control
 plane. Behaviour is packaged because it has to reach workers that may not exist
 yet. Policy is applied because it has to stay changeable — a budget you cannot
 lower without cutting a release is not a budget.


### PR DESCRIPTION
Getting started ended by showing the *shape* of a project — a tree with four files in it — and never gave anyone a file. `examples/` is no answer: those name real Zendesk and Stripe servers, so they read rather than run. So the path was: install, start a control plane, then hand-write YAML from DESIGN.md.

## Two files you can paste

The smallest agent is an objective, an input and an answer shape, plus a `worker.yaml` saying where to run it. No tools, no budget file — the loader has always allowed both to be absent, and prints what the defaults were when they are.

Both blocks are picked up by `tests/test_docs.py`, which validates every YAML block in the docs against the real schemas, so the quickstart fails the build if the schema moves under it. That check goes from 15 blocks to 17.

Below it, a pointer to `demo/leads/` for something that runs end to end against a fake network, and `examples/` labelled as reference rather than a starting point.

## The leads demo's instructions were wrong in three ways

- Never said to create the tenant, so the first command fails against any control plane that hasn't had one made by hand.
- Never said to activate the virtualenv. The agent declares its tool server as `command: python`, so the worker spawns whatever is on PATH; without the venv active that interpreter has no `mcp` and the agent quarantines at boot.
- Promised "four environment variables" above a list of six.

## Verified, not assumed

Against a control plane brought up from scratch (`down -v`, then `up`), with both YAML files extracted **programmatically out of the README** rather than retyped:

```
charter tenant create default     → tenant/default created
charter agent create summarize    → agent/summarize a7183ce5 created
charter apply .                   → v1 configured
charter worker .                  → summarize v1 0 tools 0 gated ready
charter run summarize --text "…"  → task started
charter status <id>               → outcome successful, 6s
```

```
result
  summary   Charter is a platform that transforms AI agents into controlled,
            versioned services that can be professionally operated and managed…
```

310 tests pass.
