### PR TITLE
Release 0.2.0, for the providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,11 @@ through their workers and the control plane whether or not the CLI is installed.
 ## Documentation
 
 - [DESIGN.md](DESIGN.md): every field of every file, and the decisions behind them
-- [demo/leads/](demo/leads/): an agent that finds people, asks you to approve
-  every message before it sends one, and waits days if that is how long you take.
-  It runs against a fake network on your machine, so nothing reaches anybody.
-- [examples/](examples/): fuller configurations, for reading. They name real
-  Zendesk and Stripe servers, so they do not run as-is.
 - [deploy/](deploy/): running workers as containers, and a control plane locally
+- [examples/](examples/): fuller configurations, for reading. They name real
+  Zendesk and Stripe servers, so they do not run as-is
+- [demo/leads/](demo/leads/): an agent that runs end to end against a local MCP
+  server, where you play the people it contacts
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # apiVersion stay `charter`. PyPI refuses the bare name, and the prefix is how this
 # is branded anyway.
 name = "boundflow-charter"
-version = "0.1.0"
+version = "0.2.0"
 description = "Declarative, governed agents on BoundFlow — objective, tools, and policy as YAML."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps to 0.2.0 and tidies the documentation list.

## Why a release

`pip install boundflow-charter` currently gives 0.1.0, which is **Anthropic-only** — it predates #22. Anyone who reads "bring your own model" and tries `provider: openai` on the stable release gets a validation error.

`0.2.0` and not `0.1.1`: widening a schema field is a feature, and every dev build published since the tag is already `0.2.0.devN`, which `0.1.1` would sort below.

## Documentation list

Four one-line links, ordered by what a reader needs first: DESIGN, deploy, examples, demo. The demo entry had grown into three sentences of pitch, and called `network.py` a "fake network on your machine" — what actually makes it worth running is that the replies come from you, through `inbox.py`.

After merge: `git tag v0.2.0 && git push --tags`. The trusted publisher for `publish.yml` is already configured from 0.1.0.