### PR TITLE
A quickstart someone can follow without retyping YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ per_run:
   max_llm_calls: 20
 ```
 
-`lifecycle.yaml` says what the control plane does to an agent between tasks:
+`lifecycle.yaml` acts on the agent over time. When a metric crosses a threshold the
+control plane can pause it, cool it down, or roll it back to an earlier version:
 
 ```yaml
 apiVersion: charter/v1

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ pip install --pre boundflow-charter    # or whatever main is, published every gr
 Charter needs one to run agents against. To run one locally:
 
 ```bash
-docker compose -f deploy/local.compose.yml up -d --wait
-docker compose -f deploy/local.compose.yml run --rm server -mode=provision -name=me
+curl -sSLO https://raw.githubusercontent.com/boundflow/charter/main/deploy/local.compose.yml
+docker compose -f local.compose.yml up -d --wait
+docker compose -f local.compose.yml run --rm server -mode=provision -name=me
 ```
 
 That prints an API key. With it:
@@ -54,7 +55,8 @@ export BOUNDFLOW_WORKER_ADDRESS=http://localhost:50052
 export CHARTER_STORE_URL=postgres://charter:charter@localhost:5434/charter
 ```
 
-Remove it with `docker compose -f deploy/local.compose.yml down -v`.
+Remove it with `docker compose -f local.compose.yml down -v`. Cloning the repo
+works too, and gets you the examples and the demo alongside it.
 
 For production you have two options. Run the BoundFlow backend yourself, following
 its [deployment docs](https://github.com/boundflow/boundflow/blob/main/docs/deployment.md).
@@ -67,29 +69,38 @@ Either way the control plane never sees your model key or its traffic.
 
 ### Your first agent
 
-`summarize/v1.yaml`:
+```bash
+charter init triage
+```
+
+That writes two files. `triage/v1.yaml`, the agent:
 
 ```yaml
 apiVersion: charter/v1
 kind: AgentConfig
 
-name: summarize
+name: triage
 version: 1
 model: claude-haiku-4-5
 
 objective: |
-  Summarise this in two sentences: {{ inputs.text }}
+  Triage this support ticket and say what should happen to it:
+
+  {{ inputs.ticket }}
 
 inputs:
-  text: { type: string, required: true }
+  ticket: { type: string, required: true }
 
 response_format:
-  summary:
+  category:
     type: string
-    description: The summary, in two sentences.
+    description: billing, bug, account, or other.
+  next_step:
+    type: string
+    description: What a person should do about it, in one sentence.
 ```
 
-`worker.yaml`, beside it:
+and `worker.yaml` beside it, the deployment:
 
 ```yaml
 apiVersion: charter/v1
@@ -110,7 +121,7 @@ store:
 
 agents_dir: ./
 serves:
-  - agent: summarize
+  - agent: triage
     versions: [1]
 ```
 
@@ -121,7 +132,7 @@ add them.
 
 ```bash
 charter tenant create default        # once per control plane
-charter agent create summarize       # prints an instance id
+charter agent create triage          # prints an instance id
 charter apply .                      # arm config and policy
 charter worker .                     # leave this running, it is the process
 ```
@@ -129,13 +140,36 @@ charter worker .                     # leave this running, it is the process
 Then, from another terminal:
 
 ```bash
-charter run summarize --instance <id> --text "..."
+charter run triage --instance <id> --ticket "card declined twice, tried a new one"
 charter status <task-id>
 ```
 
-## How it works
+`status` prints what the agent returned, in the shape `response_format` declared:
 
-A tool the agent shouldn't call on its own gets one line:
+```console
+task      f683f822-d8f4-40a7-b528-8db1a576140c
+outcome   successful
+took      11s
+
+inputs
+  ticket   card declined twice, tried a new one
+
+result
+  category    billing
+  next_step   Verify if the new card payment processed successfully and contact
+              the customer to resolve any ongoing payment issues.
+```
+
+The console shows the same thing in a browser, for all agents:
+
+```bash
+charter ui
+```
+
+## Approvals and policy
+
+Tools can be gated on human approval. Behaviour is versioned, so adding one means
+writing a new version file:
 
 ```yaml
 mcp:
@@ -148,18 +182,51 @@ mcp:
         approval: always
 ```
 
-When the agent decides to call `create_refund`, Charter stops the task and shows a
-human the call it wants to make and the reasoning behind it:
+Charter stops the task and shows a person the call it wants to make and the
+reasoning behind it:
 
 ```bash
 charter approve apr_01J8Z --reason "third dispute this month"
 ```
 
-The refund runs after you approve it. The agent gets the result, finishes the task,
-and reports what it did.
+Nothing waits in your terminal. The task ends at the gate and resumes when someone
+answers, which can be days later on a different worker.
 
-Nothing waited in your terminal for that. `charter apply` compiles your
-configuration into workflows and policy on the
+Limits are policy rather than behaviour, so they sit outside the version.
+`runtime.yaml` bounds a single task:
+
+```yaml
+apiVersion: charter/v1
+kind: RuntimePolicy
+agent: triage
+
+per_run:
+  max_cost_usd: 0.50
+  max_llm_calls: 20
+```
+
+`lifecycle.yaml` says what the control plane does to an agent between tasks, with
+nobody watching:
+
+```yaml
+apiVersion: charter/v1
+kind: LifecyclePolicy
+agent: triage
+
+rules:
+  - when: { metric: num_failures, threshold: 3 }
+    then: { pause: { window: 5 } }
+
+  - when: { metric: cost, threshold: 2.00 }
+    then: { set_version: { target: 1 } }
+```
+
+Both are re-applied on every `charter apply`, so a ceiling can be lowered without
+cutting a release.
+
+## Where things run
+
+`charter apply` compiles your configuration into workflows and policy on the
 [BoundFlow](https://github.com/boundflow/boundflow) control plane. A Charter worker
 runs the agent in your environment and talks to your MCP servers with credentials
 that stay there.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ charter status <task-id>
 
 `status` prints what the agent returned, in the shape `response_format` declared:
 
-```console
+```
 task      f683f822-d8f4-40a7-b528-8db1a576140c
 outcome   successful
 took      11s
@@ -205,8 +205,7 @@ per_run:
   max_llm_calls: 20
 ```
 
-`lifecycle.yaml` says what the control plane does to an agent between tasks, with
-nobody watching:
+`lifecycle.yaml` says what the control plane does to an agent between tasks:
 
 ```yaml
 apiVersion: charter/v1

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Nothing waits in your terminal. The task ends at the gate and resumes when someo
 answers, which can be days later on a different worker.
 
 Limits are policy rather than behaviour, so they sit outside the version.
-`runtime.yaml` bounds a single task:
+`runtime.yaml` holds what one task may spend and what the agent may reach:
 
 ```yaml
 apiVersion: charter/v1
@@ -203,6 +203,18 @@ agent: triage
 per_run:
   max_cost_usd: 0.50
   max_llm_calls: 20
+  max_seconds: 300
+  max_parallel_subagents: 3
+  capability_call_limits:
+    - { capability: write, max_calls: 10 }
+
+limits:
+  max_call_seconds: 60
+  max_tool_seconds: 30
+
+authority:
+  allowed_capabilities: [read, write]
+  approval_timeout_seconds: 3600
 ```
 
 `lifecycle.yaml` acts on the agent over time. When a metric crosses a threshold the

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ rules:
 Both are re-applied on every `charter apply`, so a ceiling can be lowered without
 cutting a release.
 
-## Where things run
+## Architecture
 
 `charter apply` compiles your configuration into workflows and policy on the
 [BoundFlow](https://github.com/boundflow/boundflow) control plane. A Charter worker

--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ rules:
   - when: { metric: num_failures, threshold: 3 }
     then: { pause: { window: 5 } }
 
+  - when: { metric: approval_rejections, threshold: 2 }
+    then: { cooldown: { window: 10, seconds: 3600 } }
+
   - when: { metric: cost, threshold: 2.00 }
     then: { set_version: { target: 1 } }
 ```

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -1959,7 +1959,13 @@ def console_ui(
     Read and act only. Authoring stays in the files, where a version is a diff
     with an author.
     """
-    from boundflow.ui import serve
+    try:
+        from boundflow.ui import serve
+    except ImportError:
+        # Starlette and uvicorn arrive through the extra, so a plain install
+        # reaches this line and nowhere else.
+        _err("the console needs its extra: pip install 'boundflow-charter[ui]'")
+        raise typer.Exit(1) from None
 
     from .console import LABELS
 

--- a/charter/cli.py
+++ b/charter/cli.py
@@ -28,10 +28,11 @@ import sys
 from pathlib import Path
 
 import typer
+from boundflow.errors import BoundflowError
 
-from . import ui
+from . import scaffold, ui
 from .compile import compile_agent
-from .config.agent import split_qualified
+from .config.agent import AGENT_NAME, split_qualified
 try:
     from boundflow.cli.output import is_json, output, set_json
 except ImportError:  # pragma: no cover - exercised by the compatibility test
@@ -41,7 +42,7 @@ except ImportError:  # pragma: no cover - exercised by the compatibility test
     # unpushed local merge. Delete this once #93 is in a release Charter can pin.
     from boundflow.cli._output import is_json, output, set_json
 
-from .config.loader import ConfigError, load_agent, load_project
+from .config.loader import ConfigError, load_agent, load_project, load_worker
 
 app = typer.Typer(
     add_completion=False,
@@ -50,6 +51,7 @@ app = typer.Typer(
     no_args_is_help=True,
     # \b is Click's "don't rewrap the next paragraph" marker.
     help="Governed agents from YAML.\n\n\b\n"
+         "  charter init <agent>         write a starting agent and worker\n"
          "  charter apply .              create or update agents\n"
          "  charter run <agent> --flag   start one task\n"
          "  charter agents               what every agent is doing\n"
@@ -210,6 +212,65 @@ def schema(
         depth = glob.count("/")
         rel = "../" * depth + f"{out.name}/{name}.schema.json"
         ui.detail(f"{glob:<24} # yaml-language-server: $schema={rel}")
+
+
+@app.command()
+def init(
+    name: str = typer.Argument(..., help="Agent name, which is also its directory"),
+    path: Path = typer.Option(Path("."), "--path", "-p", help="Where to write it"),
+) -> None:
+    """Write a working agent and the worker manifest that serves it.
+
+        charter init summarize
+
+    Two files: `<name>/v1.yaml` and `worker.yaml` beside it. The agent calls no
+    tools and sets no budget, which is the smallest thing that runs.
+
+    Run it again in the same directory to add a second agent, and the existing
+    `worker.yaml` gains a `serves:` entry instead of being replaced.
+    """
+    if not re.match(AGENT_NAME, name):
+        ui.err(f"{name!r} is not a valid agent name — lowercase, digits and "
+               f"hyphens, starting with a letter, 3 to 63 characters")
+        raise typer.Exit(1)
+
+    if (path / name).exists():
+        ui.err(f"{path / name} already exists")
+        raise typer.Exit(1)
+
+    written = scaffold.files(name)
+    worker = path / "worker.yaml"
+    if worker.exists():
+        # An existing manifest is the user's, so it is edited rather than
+        # replaced — and only after it parses as one of ours.
+        try:
+            manifest = load_worker(worker)
+        except ConfigError as e:
+            ui.err(f"{worker} does not parse as a Charter worker manifest: {e}")
+            raise typer.Exit(1) from None
+        if any(s.agent == name for s in manifest.serves):
+            ui.err(f"{worker} already serves {name!r}")
+            raise typer.Exit(1)
+        try:
+            worker.write_text(scaffold.add_to_serves(worker.read_text(), name))
+        except ValueError as e:
+            ui.err(f"{worker}: {e}")
+            raise typer.Exit(1) from None
+        written.pop("worker.yaml")
+
+    for rel, body in written.items():
+        target = path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+        ui.ok(str(target))
+    if not written.get("worker.yaml"):
+        ui.ok(f"{worker}  (serves: + {name})")
+
+    typer.echo()
+    ui.dim("then, with the control plane's addresses and your model key exported:")
+    ui.detail(f"charter agent create {name} --path {path}")
+    ui.detail(f"charter apply {path}")
+    ui.detail(f"charter worker {path}")
 
 
 @app.command()
@@ -1932,10 +1993,26 @@ def worker(
         asyncio.run(run_worker(project))
     except KeyboardInterrupt:
         _ok("stopped")
+    except RuntimeError as e:
+        # An unresolved ${VAR} is the common one, and it stops the worker before it
+        # claims anything. A traceback here reads as a Charter crash.
+        _err(str(e))
+        raise typer.Exit(1) from None
 
 
 def main() -> None:
-    app()
+    """Run the app, rendering control-plane failures as one line.
+
+    Every command here reaches the control plane, and the SDK already converts a
+    gRPC status into a typed error with a usable message. Left uncaught, Typer
+    prints that message under forty lines of its own internals — so a wrong task
+    id reads like a crash in Charter.
+    """
+    try:
+        app()
+    except BoundflowError as e:
+        ui.err(str(e))
+        raise SystemExit(1) from None
 
 
 if __name__ == "__main__":

--- a/charter/config/loader.py
+++ b/charter/config/loader.py
@@ -226,6 +226,19 @@ class Project:
     agents: dict[str, AgentBundle]
 
 
+def load_worker(worker_yaml: Path) -> WorkerManifest:
+    """Just the manifest, without the agents it serves.
+
+    `load_project` needs every served agent to exist on disk. Adding one to a
+    project is the case where it doesn't yet.
+    """
+    problems: list[str] = []
+    manifest = _parse(WorkerManifest, Path(worker_yaml), problems)
+    if manifest is None:
+        raise ConfigError(problems)
+    return manifest
+
+
 def load_project(worker_yaml: Path) -> Project:
     """Load a worker manifest and the agents it serves. Raises ConfigError listing
     every problem across every file."""

--- a/charter/scaffold.py
+++ b/charter/scaffold.py
@@ -1,0 +1,102 @@
+"""What `charter init` writes.
+
+The templates live here rather than in the CLI so the documentation test can hold
+the README's quickstart against them. A scaffold that drifts from the README it is
+documented by is worse than no scaffold: the reader follows the prose, the command
+writes something else, and the mismatch surfaces as a validation error against a
+file they never typed.
+
+Two files, matching the quickstart exactly: an agent that calls no tools and sets
+no budget, and the worker manifest that serves it.
+"""
+
+from __future__ import annotations
+
+AGENT = """\
+apiVersion: charter/v1
+kind: AgentConfig
+
+name: {name}
+version: 1
+model: claude-haiku-4-5
+
+objective: |
+  Triage this support ticket and say what should happen to it:
+
+  {{{{ inputs.ticket }}}}
+
+inputs:
+  ticket: {{ type: string, required: true }}
+
+response_format:
+  category:
+    type: string
+    description: billing, bug, account, or other.
+  next_step:
+    type: string
+    description: What a person should do about it, in one sentence.
+"""
+
+WORKER = """\
+apiVersion: charter/v1
+kind: Worker
+
+control_plane:
+  endpoint: ${{BOUNDFLOW_SERVER_ADDRESS}}
+  worker_endpoint: ${{BOUNDFLOW_WORKER_ADDRESS}}
+  api_key: ${{BOUNDFLOW_API_KEY}}
+  tenant: default
+
+llm:
+  provider: anthropic
+  api_key: ${{ANTHROPIC_API_KEY}}
+
+store:
+  url: ${{CHARTER_STORE_URL}}
+
+agents_dir: ./
+serves:
+  - agent: {name}
+    versions: [1]
+"""
+
+
+def files(name: str) -> dict[str, str]:
+    """Path relative to the project directory, mapped to its contents."""
+    return {f"{name}/v1.yaml": AGENT.format(name=name),
+            "worker.yaml": WORKER.format(name=name)}
+
+
+SERVES_ENTRY = "  - agent: {name}\n    versions: [1]\n"
+
+
+def add_to_serves(text: str, name: str) -> str:
+    """Append an agent to an existing manifest's `serves:` list.
+
+    Edits the text rather than reserialising the parsed document, so comments,
+    key order and formatting survive. A manifest people are told to edit by hand
+    is one a tool has no business rewriting.
+    """
+    lines = text.splitlines(keepends=True)
+    try:
+        start = next(i for i, l in enumerate(lines) if l.rstrip() == "serves:")
+    except StopIteration:
+        raise ValueError("no `serves:` list to add to") from None
+
+    # The block runs to the next line that starts its own top-level key. Blank
+    # lines and comments inside it belong to it.
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped and not lines[i][:1].isspace():
+            end = i
+            break
+
+    # Trailing blanks belong after the insertion, not before it.
+    while end > start + 1 and not lines[end - 1].strip():
+        end -= 1
+
+    entry = SERVES_ENTRY.format(name=name)
+    if not lines[end - 1].endswith("\n"):
+        lines[end - 1] += "\n"
+    return "".join(lines[:end]) + entry + "".join(lines[end:])

--- a/charter/worker.py
+++ b/charter/worker.py
@@ -322,6 +322,13 @@ class CharterWorker:
 
 
 async def run_worker(project: Project, chat_model=None) -> None:
+    if chat_model is None:
+        # Resolved here so an unset key stops the worker, rather than a worker that
+        # reports every agent ready and fails the first real task mid-dispatch.
+        llm = project.manifest.llm
+        for ref in (llm.api_key, llm.base_url):
+            if ref:
+                resolve(ref)
     worker = CharterWorker(project, chat_model=chat_model)
     try:
         await worker.run()

--- a/examples/worker.yaml
+++ b/examples/worker.yaml
@@ -4,7 +4,7 @@ kind: Worker
 name: worker-primary
 
 control_plane:
-  endpoint: ${BOUNDFLOW_ENDPOINT}
+  endpoint: ${BOUNDFLOW_SERVER_ADDRESS}
   # Where workers claim tasks — a different address from the control API.
   worker_endpoint: ${BOUNDFLOW_WORKER_ADDRESS}
   api_key: ${BOUNDFLOW_API_KEY}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ terminal.
 from __future__ import annotations
 
 import datetime as dt
+import sys
 from contextlib import asynccontextmanager
 from dataclasses import replace
 
@@ -684,3 +685,19 @@ def test_a_control_plane_error_is_one_line_not_a_traceback(cp, monkeypatch, caps
     printed = out.out + out.err
     assert "request not found" in printed
     assert "Traceback" not in printed and "raise" not in printed
+
+
+def test_the_console_names_its_extra_when_it_is_missing(monkeypatch):
+    """`charter ui` without the `[ui]` extra says how to install it.
+
+    Starlette and uvicorn arrive through that extra, so a plain
+    `pip install boundflow-charter` followed by `charter ui` hits a
+    ModuleNotFoundError traceback right after a successful first run.
+    """
+    monkeypatch.setitem(sys.modules, "boundflow.ui", None)
+
+    res = runner.invoke(cli.app, ["ui"])
+
+    assert res.exit_code == 1
+    assert "boundflow-charter[ui]" in res.output
+    assert "Traceback" not in res.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -658,3 +658,29 @@ def test_the_renderer_is_found_under_either_name():
         assert all(callable(getattr(mod, f, None))
                    for f in ("output", "set_json", "is_json")), name
     assert found, "neither renderer module is importable"
+
+
+def test_a_control_plane_error_is_one_line_not_a_traceback(cp, monkeypatch, capsys):
+    """A wrong id prints `error: <what the server said>` and exits 1.
+
+    The SDK already raises a typed error with a usable message. Uncaught, Typer
+    prints it under forty lines of its own internals, so `charter status` on a
+    mistyped id reads as a crash in Charter. Exercised through `main`, because
+    that is where the handling lives and what the installed script calls.
+    """
+    from boundflow.errors import NotFoundError
+
+    async def missing(self, request_id):
+        raise NotFoundError("request not found")
+
+    monkeypatch.setattr(cp, "get_request_info", missing.__get__(cp), raising=False)
+    monkeypatch.setattr("sys.argv", ["charter", "status", "nope"])
+
+    with pytest.raises(SystemExit) as exit:
+        cli.main()
+
+    assert exit.value.code == 1
+    out = capsys.readouterr()
+    printed = out.out + out.err
+    assert "request not found" in printed
+    assert "Traceback" not in printed and "raise" not in printed

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -57,3 +57,77 @@ def test_documented_yaml_is_valid(name, index, block):
     if model is None:
         return
     model.model_validate(doc)
+
+
+def test_readme_quickstart_is_what_init_writes():
+    """The quickstart YAML the README prints is byte-for-byte what `charter init`
+    produces, so following the prose and running the command give the same files.
+
+    Drift here is silent and lands on a first-time reader: they copy the README,
+    the scaffold wrote something else, and the error names a file they never typed.
+    """
+    from charter import scaffold
+
+    readme = (ROOT / "README.md").read_text()
+    blocks = re.findall(r"```ya?ml\n(.*?)```", readme, re.S)
+    for body in scaffold.files("triage").values():
+        assert body in blocks, (
+            "README's quickstart no longer matches `charter init` — update whichever "
+            f"of the two is wrong. Missing:\n{body}")
+
+
+def test_init_writes_configs_that_load(tmp_path):
+    """`charter init` produces a project that `charter validate` accepts.
+
+    A scaffold that needs editing before it parses is not a scaffold.
+    """
+    from charter import scaffold
+    from charter.config.loader import load_project
+
+    for rel, body in scaffold.files("triage").items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+    project = load_project(tmp_path / "worker.yaml")
+    assert set(project.agents) == {"triage"}
+    assert set(project.agents["triage"].versions) == {1}
+
+
+def test_init_adds_a_second_agent_to_an_existing_manifest(tmp_path):
+    """A second `charter init` in the same project extends `serves:` rather than
+    refusing, which is how someone adds their next agent.
+
+    The manifest is edited as text, so comments and formatting a person wrote
+    survive the edit.
+    """
+    from charter import scaffold
+    from charter.config.loader import load_project
+
+    for rel, body in scaffold.files("triage").items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+    worker = tmp_path / "worker.yaml"
+    worker.write_text(worker.read_text().replace(
+        "serves:", "# the agents this process serves\nserves:"))
+
+    worker.write_text(scaffold.add_to_serves(worker.read_text(), "escalations"))
+    (tmp_path / "escalations").mkdir()
+    (tmp_path / "escalations" / "v1.yaml").write_text(
+        scaffold.files("escalations")["escalations/v1.yaml"])
+
+    assert "# the agents this process serves" in worker.read_text()
+    project = load_project(worker)
+    assert set(project.agents) == {"triage", "escalations"}
+
+
+def test_add_to_serves_keeps_trailing_content(tmp_path):
+    """The entry lands inside `serves:`, not after whatever follows it."""
+    from charter import scaffold
+
+    text = scaffold.WORKER.format(name="triage") + "\nmodel_pricing:\n  x: { input: 1, output: 2 }\n"
+    out = scaffold.add_to_serves(text, "escalations")
+    assert out.index("- agent: escalations") < out.index("model_pricing:")
+    assert out.endswith("  x: { input: 1, output: 2 }\n")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -5,8 +5,11 @@ BoundFlow serves the control API and worker dispatch on different addresses. Onl
 a CLI talking to it and a worker dialling localhost.
 """
 import ast
+import asyncio
 import inspect
 from pathlib import Path
+
+import pytest
 
 from charter.config.worker import ControlPlane
 
@@ -43,3 +46,31 @@ def test_a_worker_endpoint_is_carried_when_given():
     cp = ControlPlane(endpoint="https://api.example:443", api_key="k", tenant="t",
                       worker_endpoint="https://worker.example:443")
     assert cp.worker_endpoint == "https://worker.example:443"
+
+
+def test_a_worker_with_an_unresolved_model_key_refuses_to_start(tmp_path, monkeypatch):
+    """An unset ${VAR} in `llm` stops the worker before it claims anything.
+
+    Resolved lazily, the worker boots, prints every agent as ready, and dies
+    mid-dispatch on the first real task — which fails that task and reads as a
+    Charter bug rather than a missing export.
+    """
+    from charter import scaffold
+    from charter.config.loader import load_project
+    from charter.worker import run_worker
+
+    for rel, body in scaffold.files("triage").items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    def built(*a, **k):
+        raise AssertionError("the worker was constructed before the key was checked")
+
+    monkeypatch.setattr("charter.worker.CharterWorker", built)
+
+    with pytest.raises(RuntimeError) as e:
+        asyncio.run(run_worker(load_project(tmp_path / "worker.yaml")))
+    assert "ANTHROPIC_API_KEY" in str(e.value)


### PR DESCRIPTION
`charter init <name>` writes a working agent and the worker manifest that serves it. Run it again in the same directory and the existing manifest gains a `serves:` entry instead of being refused, which is how a second agent gets added. The manifest is edited as text, so comments and formatting survive.

Motivated by `pipx install boundflow-charter`, which leaves someone with no repo and two YAML files to retype out of the README.

## Two bugs, found by running the quickstart end to end

Both on the path a first-time reader takes, neither covered by any test.

- Any control-plane error printed forty lines of SDK traceback. The SDK already raises a typed error with a usable message, so `main` catches `BoundflowError` and prints one line. This was every command, not just `status`.
- An unset model key went unnoticed until a task was already running: the worker booted, listed every agent as `ready`, then died mid-dispatch and failed the task. It now resolves the key before claiming anything.

## README

- The control plane is fetched with `curl` rather than cloned. The compose file is all `image:` lines, so nothing needed the repo.
- `charter init` leads the quickstart, with the files shown underneath as what it wrote.
- `charter status` shows its real output, copied from an actual run.
- `charter ui` is named. The hero GIF promised a console and nothing said how to open it.
- Approvals and policy move out of the quickstart into their own section. Neither runs without credentials a reader does not have, and every line of a quickstart should be executable.
- `examples/worker.yaml` referenced `BOUNDFLOW_ENDPOINT`, which no other file or test uses.

## Verified

The whole quickstart run against a local control plane and a real model, in order: curl, `up --wait`, provision, `init`, `tenant create`, `agent create`, `apply`, `worker`, `run`, `status`. The task came back `successful` with the structured result the config declares.

312 unit tests pass. Six are new, and each of the two bug fixes was confirmed to fail without its fix.