### PR TITLE
Release 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # apiVersion stay `charter`. PyPI refuses the bare name, and the prefix is how this
 # is branded anyway.
 name = "boundflow-charter"
-version = "0.2.0"
+version = "0.2.1"
 description = "Declarative, governed agents on BoundFlow — objective, tools, and policy as YAML."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
`charter init`, the two first-run error fixes, and the README quickstart rework. Every step verified against a live control plane and a real model.