### PR TITLE
Show the instance id in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,18 @@ charter apply .                      # arm config and policy
 charter worker .                     # leave this running, it is the process
 ```
 
-Then, from another terminal:
+Then, from another terminal, `charter agents` confirms it exists and carries the
+instance id every command needs:
+
+```
+AGENT   INSTANCE  VER  STATUS  ACTIVITY
+triage  d9811374  v1   active  active
+```
+
+Run a task against it:
 
 ```bash
-charter run triage --instance <id> --ticket "card declined twice, tried a new one"
+charter run triage --instance d9811374 --ticket "card declined twice, tried a new one"
 charter status <task-id>
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ triage  d9811374  v1   active  active
 Run a task against it:
 
 ```bash
-charter run triage --instance d9811374 --ticket "card declined twice, tried a new one"
+charter run triage --instance d9811374 --ticket "card declined twice, tried a new one"  # prints a task id
 charter status <task-id>
 ```
 


### PR DESCRIPTION
`charter run` needs an instance id that only `agent create` printed, with nothing showing how to recover it. `charter agents` both confirms the agent exists and carries the id, so it goes in the quickstart with its real output.

Output copied from a live run, not written by hand.