### PR TITLE
Export the model key in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ export BOUNDFLOW_API_KEY=<the key it printed>
 export BOUNDFLOW_SERVER_ADDRESS=http://localhost:50051
 export BOUNDFLOW_WORKER_ADDRESS=http://localhost:50052
 export CHARTER_STORE_URL=postgres://charter:charter@localhost:5434/charter
+export ANTHROPIC_API_KEY=<your model key>   # or another provider's, see worker.yaml below
 ```
 
 Remove it with `docker compose -f local.compose.yml down -v`. Cloning the repo
@@ -113,6 +114,8 @@ control_plane:
   tenant: default
 
 llm:
+  # Any provider LangChain can build. Name it here, put its key in the variable
+  # below, and install its package: pip install 'boundflow-charter[openai]'
   provider: anthropic
   api_key: ${ANTHROPIC_API_KEY}
 

--- a/charter/scaffold.py
+++ b/charter/scaffold.py
@@ -48,6 +48,8 @@ control_plane:
   tenant: default
 
 llm:
+  # Any provider LangChain can build. Name it here, put its key in the variable
+  # below, and install its package: pip install 'boundflow-charter[openai]'
   provider: anthropic
   api_key: ${{ANTHROPIC_API_KEY}}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,9 @@ dependencies = [
     # A separate distribution from langgraph: `langgraph.checkpoint.postgres` and
     # `langgraph.store.postgres`.
     "langgraph-checkpoint-postgres>=3.1",
-    # The only model provider wired up today — `worker.yaml` refuses any other.
-    # `init_chat_model` lives here, and it is how a provider gets built. Declared
-    # rather than inherited from deepagents: we import it directly now.
+    # `init_chat_model` lives here, and it is how `llm.provider` gets built, so any
+    # provider LangChain supports works. Declared rather than inherited from
+    # deepagents: we import it directly.
     "langchain>=1.0",
     # Anthropic is the only integration installed by default, because a default has
     # to be something. Any other provider is an extra, or install its package.


### PR DESCRIPTION
Follows #27, which merged before these landed on its branch.

- The quickstart's export block never mentioned `ANTHROPIC_API_KEY`, which the scaffolded `worker.yaml` references. Since #25 the worker refuses to start without it, so a reader who never saw the variable is stopped at the door rather than failing later.
- How to use a different provider goes in `worker.yaml` itself, beside the field you would change. It ships in what `charter init` writes.
- `pyproject.toml` still claimed `worker.yaml` refuses any provider but Anthropic. That stopped being true when `llm.provider` widened to a string and `init_chat_model` took over.