### PR TITLE
Release 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 # apiVersion stay `charter`. PyPI refuses the bare name, and the prefix is how this
 # is branded anyway.
 name = "boundflow-charter"
-version = "0.2.1"
+version = "0.3.0"
 description = "Declarative, governed agents on BoundFlow — objective, tools, and policy as YAML."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `pyproject.toml` to 0.3.0. Once this merges, pushing tag `v0.3.0` publishes to PyPI. `publish.yml` refuses if the tag and this version disagree.

The released 0.2.1 rejects the current examples (`justify: Extra inputs are not permitted`), so `pip install boundflow-charter` users can't run them until this ships.

Minor rather than patch: new config fields (`max_proposals`, `justify`), workers now take their limits from the control plane instead of local `runtime.yaml`, and `charter run --path` is removed.

No BoundFlow pin change. PR 108 is server-side, and `boundflow>=0.7.0` is the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
