### PR TITLE
Say what Charter is, the way the golden repos do

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
-Charter is the open-source alternative to managed agent platforms. Define your agent
-and its policies in YAML, run it in your environment with your models and tools, and
-let Charter's persistent control plane handle its operational lifecycle — without
-requiring your model credentials, prompts, tool traffic, or private infrastructure
-access to leave your execution environment.
+Charter is open-source infrastructure for running AI agents in production. You
+define an agent and its policies in YAML. Charter runs it in your environment, with
+your models and tools, and governs it from a persistent control plane.
 
 ## Why Charter
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ![The Charter console: the fleet with an agent parked on an approval, the decision waiting on a human, and the policy and run history behind it](docs/console.gif)
 
-Charter is open-source infrastructure for running AI agents in production. You
-define an agent and its policies in YAML. Charter runs it in your environment, with
-your models and tools, and governs it from a persistent control plane.
+Charter is an open-source platform for running AI agents in production. You define
+an agent and its policies in YAML. Charter runs it on your compute and governs it
+from a persistent control plane.
 
 ## Why Charter
 


### PR DESCRIPTION
Replaces the README opener with the original's shape, plus "is an open-source platform" in the first sentence.

> Charter is an open-source platform for running AI agents in production. You define an agent and its policies in YAML. Charter runs it on your compute and governs it from a persistent control plane.

The previous version defined Charter by the platforms it replaces, ended on a list of what never leaves your environment (the Your network, your data bullet already covers that), and called the control plane Charter's when it's BoundFlow's.

Every golden repo opens with "X is a ...": Temporal, Prefect, LangGraph, Pydantic AI, Supabase. deepagents, which Charter is built on, puts open source in that sentence too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)