### PR TITLE
Pin returned MCP tool errors against max_tool_failures

### DIFF
--- a/charter/mcp/client.py
+++ b/charter/mcp/client.py
@@ -305,22 +305,20 @@ class ToolSet:
         # so a server named `desk_get` with a tool `ticket` collides with `desk` and
         # `get_ticket`. Charter's `__` is unambiguous, and it's already baked into
         # tool_call_limits and lifecycle rules.
-        # NOTE: `handle_tool_errors` is left at its default of True, and that
-        # currently costs us failure counting. The adapter turns a failing tool
-        # into a *returned* error string, and BoundFlow's wrapper counts a failure
-        # only when a call raises — so an MCP tool failure is recorded as a
-        # success. tool_failure_counts stays empty, max_tool_failures never trips,
-        # and `on_failure: fail` never fires. Same shape as reading `isError` under
-        # its 1.x name, which this file has already been bitten by once.
+        # `handle_tool_errors` stays at its default of True on purpose. The
+        # adapter turns a failing tool into a *returned* error string rather than
+        # raising; setting it False lets that exception unwind the whole
+        # invocation, so one broken tool kills the run instead of being reported
+        # to the model. Measured, not assumed.
         #
-        # Setting it False is worse, not better: the exception then propagates out
-        # of the whole invocation, so one failing tool kills the run instead of
-        # being reported to the model, and the agent loses the chance to work
-        # around it. Measured, not assumed.
-        #
-        # The real fix is to classify the returned error in the governed wrapper,
-        # the way a policy denial already is — count it *and* let the model read
-        # it. Tracked separately rather than bodged here.
+        # Counting the returned error is BoundFlow's job — the governed wrapper
+        # classifies `"Error executing tool …"` (and `status="error"`) as a
+        # failure *and* hands the text back, which is what lets
+        # `tool_failure_counts`, `max_tool_failures` and `on_failure: fail` see
+        # declared MCP tools. The hang path below uses the same wording so it
+        # is counted on that path too. Pinned by
+        # `tests/e2e/test_failures.py::test_a_returned_mcp_error_trips_the_failure_breaker`
+        # and `test_a_broken_tool_fails_the_task_naming_the_tool`.
         self._client = MultiServerMCPClient(
             {s.name: _connection(s) for s in cfg.mcp})
 

--- a/tests/e2e/test_failures.py
+++ b/tests/e2e/test_failures.py
@@ -86,6 +86,55 @@ async def test_a_broken_tool_fails_the_task_naming_the_tool(cp, project, tenant)
     assert "always_fails" in info.result["reason"]
 
 
+async def test_a_returned_mcp_error_trips_the_failure_breaker(cp, project, tenant):
+    """The other half of #7. `on_failure: fail` is already pinned above.
+
+    `always_fails` raises inside a real MCP server. The adapter turns that into a
+    *returned* error string rather than an exception, which is what used to make
+    BoundFlow's wrapper count a success: `tool_failure_counts` stayed empty and
+    `max_tool_failures` never tripped, so a broken integration burned the budget
+    instead of its own breaker.
+
+    No `on_failure: fail` here on purpose. The first call must be counted *and*
+    handed back, or the model never gets a second turn. The second call is what
+    trips the cap. Written so the old wrapper would let this task finish.
+    """
+    path = project.path.parent / "ticket-sweeper" / "v1.yaml"
+    raw = yaml.safe_load(path.read_text())
+    raw["mcp"][0]["tools"].append({"tool": "always_fails"})
+    raw["objective"] = "Call always_fails twice, then report."
+    path.write_text(yaml.safe_dump(raw))
+
+    runtime = project.path.parent / "ticket-sweeper" / "runtime.yaml"
+    limits = yaml.safe_load(runtime.read_text())
+    limits["per_run"]["max_tool_failures"] = 1
+    runtime.write_text(yaml.safe_dump(limits))
+    reloaded = load_project(project.path)
+
+    wf = await one_instance(cp, reloaded, "ticket-sweeper", tenant)
+    model = scripted(
+        calls("desk__always_fails", why="testing"),
+        calls("desk__always_fails", why="again"),
+        submits(summary="worked around it", needs_attention=0),
+    )
+
+    info = await run_one(cp, reloaded, "ticket-sweeper", wf, model)
+
+    assert info.result.get("failed") is True, (
+        f"a returned MCP error was not counted, so the breaker never tripped — "
+        f"{info.result}")
+    reason = info.result["reason"]
+    assert "always_fails" in reason, reason
+    assert "max_failures" in reason, reason
+    assert "on_failure" not in reason, reason
+
+    metrics = await cp.get_workflow_metrics(wf.id)
+    counted = metrics.tool_failure_counts.get("desk__always_fails", 0)
+    assert counted == 2, (
+        f"expected both returned errors counted against the cap of 1, got "
+        f"{metrics.tool_failure_counts}")
+
+
 async def test_a_spent_budget_says_which_ceiling_it_hit(cp, project, tenant):
     """Not "it went round a lot" — the reason names the number that stopped it, so
     an operator knows whether to raise it or fix the agent."""

--- a/tests/test_mcp_live.py
+++ b/tests/test_mcp_live.py
@@ -140,9 +140,8 @@ def test_a_failing_tool_reports_its_error_to_the_model():
     one broken tool from killing a run — the model reads the error and can work
     around it.
 
-    The cost is that BoundFlow's wrapper counts a failure only on a raise, so this
-    is currently invisible to tool_failure_counts. See the note in client.py; the
-    fix belongs in the wrapper, not here.
+    Counting that returned error is the governed wrapper's job, not this client's.
+    The e2e suite pins that `tool_failure_counts` and `max_tool_failures` see it.
     """
     async def go():
         ts = await _connected([ToolSpec(tool="get_ticket"),


### PR DESCRIPTION
## Summary
- #7 is already fixed in the BoundFlow wrapper (it classifies a returned `Error executing tool …` / `status=error`, counts it, and still hands the text to the model). This PR does not redo that.
- Adds an e2e test for the half that was still unpinned: a real MCP `always_fails` (raise → adapter returns a string, no `on_failure: fail`) increments `tool_failure_counts` and trips `max_tool_failures`. The old wrapper would have let the task finish. The existing test only covers `on_failure: fail`.
- Updates the note in `charter/mcp/client.py` and the matching comment in `test_mcp_live.py` so they stop saying the bug is still live.

Closes #7.

## Test plan
- [x] `pytest` (unit)
- [x] `pytest tests/e2e/test_failures.py::test_a_returned_mcp_error_trips_the_failure_breaker`
- [x] `pytest tests/e2e` (full suite, twice)